### PR TITLE
Traefiklb 2022

### DIFF
--- a/2022_07_15-traefik-load-balancing/.gitignore
+++ b/2022_07_15-traefik-load-balancing/.gitignore
@@ -1,0 +1,9 @@
+ansible/traefik_inventory
+ansible/group_vars/*.yaml
+packer/output/
+packer/preseed/debian10.txt.password
+packer/packer_cache/
+packer_cache/
+terraform/.terraform/
+terraform/*.tfstate
+terraform/*.tfstate.*

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -79,7 +79,7 @@ build-image: ## Build image with Packer.
 
 upload-image: ## Upload image to libvirt with virsh.
 	$(eval  size = $(shell stat -Lc%s packer/output/debian11))
-	mkdir $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)
+	test -d $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) || mkdir $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) dir --target $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) 2>/dev/null || echo "did not create pool"
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-start $(LIBVIRT_TEMPLATES_IMAGES_POOL) 2>/dev/null || echo "did not enable pool"
 	- virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -67,6 +67,7 @@ install-terraform-plugins:
 qemu-user:
 	sed -i 's/\#user = \"root\"/user = \"root\"/g' /etc/libvirt/qemu.conf
 	sed -i 's/\#group = \"root\"/group = \"root\"/g' /etc/libvirt/qemu.conf
+	sed -i 's/\#security_driver = \"selinux\"/security_driver = \"none\"/g' /etc/libvirt/qemu.conf
 	systemctl restart libvirtd
 
 image: build-image upload-image ## Build image with Packer and upload it to libvirt with virsh.

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -83,7 +83,7 @@ upload-image: ## Upload image to libvirt with virsh.
 	test -d $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) || mkdir $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) dir --target $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) 2>/dev/null || echo "did not create pool"
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-start $(LIBVIRT_TEMPLATES_IMAGES_POOL) 2>/dev/null || echo "did not enable pool"
-	test -f $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)/$(LIBVIRT_IMAGE_NAME) || virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)
+	test ! -f $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)/$(LIBVIRT_IMAGE_NAME) || virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) $(size) --format qcow2 && \
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-upload --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) packer/output/debian11
 

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -83,7 +83,7 @@ upload-image: ## Upload image to libvirt with virsh.
 	test -d $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) || mkdir $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) dir --target $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) 2>/dev/null || echo "did not create pool"
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-start $(LIBVIRT_TEMPLATES_IMAGES_POOL) 2>/dev/null || echo "did not enable pool"
-	test -f $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)/$(LIBVIRT_IMAGE_NAME) || (virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME))
+	test ! -e $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)/$(LIBVIRT_IMAGE_NAME) || virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) $(size) --format qcow2 && \
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-upload --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) packer/output/debian11
 

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -82,7 +82,7 @@ upload-image: ## Upload image to libvirt with virsh.
 	test -d $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) || mkdir $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) dir --target $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) 2>/dev/null || echo "did not create pool"
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-start $(LIBVIRT_TEMPLATES_IMAGES_POOL) 2>/dev/null || echo "did not enable pool"
-	- virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)
+	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) $(size) --format qcow2 && \
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-upload --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) packer/output/debian11
 

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -1,0 +1,120 @@
+.PHONY: help all check-env my-linux-env create-env install-packer install-terraform install-ansible install-terraform-plugins image build-image upload-image import-kube-nodes create-vms run-playbook destroy
+.DEFAULT_GOAL := all
+
+LOCAL_BIN := ~/.local/bin/
+PACKER_VERSION := 1.8.2
+TERRAFORM_PLUGIN_DIR := ~/.terraform.d/plugins
+TERRAFORM_VERSION := 1.2.3
+TERRAFORM_LIBVIRT_FULL_VERSION := 0.6.14_linux_amd64
+TERRAFORM_LIBVIRT_VERSION := 0.6.14#if you change that, change also terraform/traefik.tf
+TERRAFORM_ANSIBLE_VERSION := 2.5.0
+ANSIBLE_VERSION := 2.10.8
+LIBVIRT_HYPERVISOR_URI := "qemu:///system"
+LIBVIRT_TEMPLATES_IMAGES_POOL := "templates"
+LIBVIRT_TEMPLATES_IMAGES_POOL_DIR := "/var/lib/libvirt/images/templates"
+LIBVIRT_IMAGE_NAME := "debian11-traefik.qcow2"
+ROOT_PASSWORD := "traefik"
+CLUSTER := 1
+TRAEFIKEE_LICENSE := "N/A"
+$(eval SSH_IDENTITY=$(shell find ~/.ssh/ -name 'id_*' -not -name '*.pub' | head -n 1))
+#SSH_IDENTITY := "~/.ssh/id_rsa_unencrypted"
+
+help: ## This help.
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+all:
+
+check-env: ## Check environment.
+	@(which unzip 2>&1 > /dev/null) || (echo "unzip is not in your PATH" && exit 1)
+	@(which curl 2>&1 > /dev/null) || (echo "curl is not in your PATH" && exit 1)
+	@(which virsh 2>&1 > /dev/null) || (echo "virsh is not in your PATH" && exit 1)
+	@(terraform version 2>&1 | grep -E 'v0.1([4-9].[0-9]|3.[3-9])' > /dev/null) || (echo "terraform is not in your PATH or is not up to date" && exit 1)
+	@(packer version 2>&1 | grep -E 'v1.([7-9].[0-9]|6.[2-9])' > /dev/null) || (echo "packer is not in your PATH or is not up to date" && exit 1)
+	@(ansible --version | head -n 1 | grep -E '(2.9.(1[3-9]|[2-9][0-9])|[3-9].[0-9].[0-9])' > /dev/null) || (echo "ansible is not in your PATH or is not up to date" && exit 1)
+	@(id -u | id -nGz | grep -qzxF libvirt) || (echo "you are not in the libvirt group" && exit 1)
+	@echo "You're ready to play!"
+
+my-linux-env: create-env install-packer install-terraform install-terraform-plugins install-ansible ## Install environment.
+
+create-env: ## Create directories and set env variables for binary dependencies.
+	test -d $(LOCAL_BIN)|| mkdir -p $(LOCAL_BIN)
+	echo ${PATH} | grep $(LOCAL_BIN) || (echo 'export PATH=$$PATH:~/.local/bin/' >> ~/.bashrc; . ~/.bashrc)
+
+install-packer: ## Install Packer.
+	test -f $(LOCAL_BIN)packer || \
+	(curl https://releases.hashicorp.com/packer/$(PACKER_VERSION)/packer_$(PACKER_VERSION)_linux_amd64.zip -o /tmp/packer_$(PACKER_VERSION)_linux_amd64.zip; \
+	unzip /tmp/packer_$(PACKER_VERSION)_linux_amd64.zip -d $(LOCAL_BIN); \
+	rm -f /tmp/packer_$(PACKER_VERSION)_linux_amd64.zip); \
+	chmod +x $(LOCAL_BIN)packer
+
+install-terraform: ## Install Terraform.
+	test -f $(LOCAL_BIN)terraform || \
+	(curl -q https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_linux_amd64.zip -o /tmp/terraform_$(TERRAFORM_VERSION)_linux_amd64.zip; \
+	unzip /tmp/terraform_$(TERRAFORM_VERSION)_linux_amd64.zip -d $(LOCAL_BIN); \
+	rm -f /tmp/terraform_$(TERRAFORM_VERSION)_linux_amd64.zip); \
+	chmod +x $(LOCAL_BIN)terraform
+
+install-ansible: ## Install Ansible with pip.
+	pip3 freeze | grep ansible==$(ANSIBLE_VERSION) || pip3 install ansible
+
+install-terraform-plugins:
+	test -d $(TERRAFORM_PLUGIN_DIR)/github.com/dmacvicar/libvirt/$(TERRAFORM_LIBVIRT_VERSION)/linux_amd64/ || mkdir -p $(TERRAFORM_PLUGIN_DIR)/github.com/dmacvicar/libvirt/$(TERRAFORM_LIBVIRT_VERSION)/linux_amd64/; \
+	test -f $(TERRAFORM_PLUGIN_DIR)/github.com/dmacvicar/libvirt/$(TERRAFORM_LIBVIRT_VERSION)/linux_amd64/terraform-provider-libvirt || \
+	(curl -L https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v$(TERRAFORM_LIBVIRT_VERSION)/terraform-provider-libvirt_$(TERRAFORM_LIBVIRT_FULL_VERSION).zip -o /tmp/terraform-provider-libvirt-$(TERRAFORM_LIBVIRT_VERSION).zip && mkdir -p $(TERRAFORM_PLUGIN_DIR)/github.com/dmacvicar/libvirt/$(TERRAFORM_LIBVIRT_VERSION)/linux_amd64 && unzip -j /tmp/terraform-provider-libvirt-$(TERRAFORM_LIBVIRT_VERSION).zip terraform-provider-libvirt_v$(TERRAFORM_LIBVIRT_VERSION) -d $(TERRAFORM_PLUGIN_DIR)/github.com/dmacvicar/libvirt/$(TERRAFORM_LIBVIRT_VERSION)/linux_amd64/ && mv $(TERRAFORM_PLUGIN_DIR)/github.com/dmacvicar/libvirt/$(TERRAFORM_LIBVIRT_VERSION)/linux_amd64/terraform-provider-libvirt_v$(TERRAFORM_LIBVIRT_VERSION) $(TERRAFORM_PLUGIN_DIR)/github.com/dmacvicar/libvirt/$(TERRAFORM_LIBVIRT_VERSION)/linux_amd64/terraform-provider-libvirt && rm -f /tmp/terraform-provider-libvirt-$(TERRAFORM_LIBVIRT_VERSION).zip); \
+	test -f $(TERRAFORM_PLUGIN_DIR)/terraform-provisioner-ansible || \
+	(curl -L https://github.com/radekg/terraform-provisioner-ansible/releases/download/v$(TERRAFORM_ANSIBLE_VERSION)/terraform-provisioner-ansible-linux-amd64_v$(TERRAFORM_ANSIBLE_VERSION) -o $(TERRAFORM_PLUGIN_DIR)/terraform-provisioner-ansible && chmod +x $(TERRAFORM_PLUGIN_DIR)/terraform-provisioner-ansible)
+
+qemu-user:
+	sed -i 's/\#user = \"root\"/user = \"root\"/g' /etc/libvirt/qemu.conf
+	sed -i 's/\#group = \"root\"/group = \"root\"/g' /etc/libvirt/qemu.conf
+	systemctl restart libvirtd
+
+image: build-image upload-image ## Build image with Packer and upload it to libvirt with virsh.
+
+build-image: ## Build image with Packer.
+	rm -rf  packer/output
+	$(eval CRYPTED_PASSWORD = $$(shell openssl passwd -6 "$(ROOT_PASSWORD)"))
+	sed -r 's@^(d-i passwd\/root-password-crypted password).*@\1 $(CRYPTED_PASSWORD)@g' packer/preseed/debian11.txt > packer/preseed/debian11.txt.password
+	cd packer && ROOT_PASSWORD=$(ROOT_PASSWORD) SSH_PUB_KEY="$(shell cat $(SSH_IDENTITY).pub)" packer build base.json
+
+upload-image: ## Upload image to libvirt with virsh.
+	$(eval  size = $(shell stat -Lc%s packer/output/debian11))
+	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) dir --target $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) 2>/dev/null || echo "did not create pool"
+	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-start $(LIBVIRT_TEMPLATES_IMAGES_POOL) 2>/dev/null || echo "did not enable pool"
+	- virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)
+	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) $(size) --format qcow2 && \
+	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-upload --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) packer/output/debian11
+
+import-kube-nodes: ## Use some Terraform resources from step 1 in step 2, and some resources from step 2 in step 3.
+	[ $(CLUSTER) -eq 2 ] && { \
+	cd terraform ; \
+	[ -f cluster1.tfstate ] && ! [ -f cluster2.tfstate ] && { \
+	cp cluster1.tfstate cluster1.tfstate.copy; \
+	terraform state mv -state=cluster1.tfstate.copy -state-out=cluster2.tfstate libvirt_network.network libvirt_network.network; \
+	terraform state mv -state=cluster1.tfstate.copy -state-out=cluster2.tfstate libvirt_pool.images libvirt_pool.images; \
+	rm -f cluster1.tfstate.copy ; \
+	} \
+	} || echo "not importing"
+	[ $(CLUSTER) -eq 3 ] && { \
+	cd terraform ; \
+	[ -f cluster2.tfstate ] && ! [ -f cluster3.tfstate ] && { \
+	cp cluster2.tfstate cluster2.tfstate.copy; \
+	for i in 3 4 5 ; do \
+		terraform state mv -state=cluster2.tfstate.copy -state-out=cluster3.tfstate libvirt_domain.vm[$$i] libvirt_domain.vm[$$((i+1))]; \
+	done; \
+	terraform state mv -state=cluster2.tfstate.copy -state-out=cluster3.tfstate libvirt_network.network libvirt_network.network; \
+	terraform state mv -state=cluster2.tfstate.copy -state-out=cluster3.tfstate libvirt_pool.images libvirt_pool.images; \
+	rm -f cluster2.tfstate.copy ; \
+	} \
+	} || echo "not importing"
+
+# If there is a problem of rights when the VM is starting, you have to follow
+# https://github.com/dmacvicar/terraform-provider-libvirt/commit/22f096d94f2480a678c388cb2d8eff91425ed13d
+create-vms: import-kube-nodes ## Apply Terraform.
+	cd terraform && terraform init && terraform apply -auto-approve -var "libvirt_uri=$(LIBVIRT_HYPERVISOR_URI)" -var "ssh_key=$(SSH_IDENTITY)" -var "templates_pool=$(LIBVIRT_TEMPLATES_IMAGES_POOL)" -var "template_img=$(LIBVIRT_IMAGE_NAME)" -var-file="cluster$(CLUSTER).tfvars" -state="cluster$(CLUSTER).tfstate"
+
+run-playbook: create-vms ## Apply Ansible playbook.
+	cd ansible && ansible-playbook -u root -i traefik_inventory -e "traefikee_license_key=$(TRAEFIKEE_LICENSE_KEY)" site.yml
+
+destroy: ## Destroy Terraform resources.
+	cd terraform && terraform destroy -auto-approve -state="cluster$(CLUSTER).tfstate"

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -83,7 +83,7 @@ upload-image: ## Upload image to libvirt with virsh.
 	test -d $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) || mkdir $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) dir --target $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) 2>/dev/null || echo "did not create pool"
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-start $(LIBVIRT_TEMPLATES_IMAGES_POOL) 2>/dev/null || echo "did not enable pool"
-	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)
+	test -f $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)/$(LIBVIRT_IMAGE_NAME) || virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) $(size) --format qcow2 && \
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-upload --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) packer/output/debian11
 

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -79,6 +79,7 @@ build-image: ## Build image with Packer.
 
 upload-image: ## Upload image to libvirt with virsh.
 	$(eval  size = $(shell stat -Lc%s packer/output/debian11))
+	mkdir $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) dir --target $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) 2>/dev/null || echo "did not create pool"
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-start $(LIBVIRT_TEMPLATES_IMAGES_POOL) 2>/dev/null || echo "did not enable pool"
 	- virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -83,7 +83,7 @@ upload-image: ## Upload image to libvirt with virsh.
 	test -d $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) || mkdir $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) dir --target $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR) 2>/dev/null || echo "did not create pool"
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) pool-start $(LIBVIRT_TEMPLATES_IMAGES_POOL) 2>/dev/null || echo "did not enable pool"
-	test ! -f $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)/$(LIBVIRT_IMAGE_NAME) || virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME)
+	test -f $(LIBVIRT_TEMPLATES_IMAGES_POOL_DIR)/$(LIBVIRT_IMAGE_NAME) || (virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-list $(LIBVIRT_TEMPLATES_IMAGES_POOL) | grep $(LIBVIRT_IMAGE_NAME) && virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-delete --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME))
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-create-as $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) $(size) --format qcow2 && \
 	virsh -c $(LIBVIRT_HYPERVISOR_URI) vol-upload --pool $(LIBVIRT_TEMPLATES_IMAGES_POOL) $(LIBVIRT_IMAGE_NAME) packer/output/debian11
 

--- a/2022_07_15-traefik-load-balancing/Makefile
+++ b/2022_07_15-traefik-load-balancing/Makefile
@@ -64,7 +64,7 @@ install-terraform-plugins:
 	test -f $(TERRAFORM_PLUGIN_DIR)/terraform-provisioner-ansible || \
 	(curl -L https://github.com/radekg/terraform-provisioner-ansible/releases/download/v$(TERRAFORM_ANSIBLE_VERSION)/terraform-provisioner-ansible-linux-amd64_v$(TERRAFORM_ANSIBLE_VERSION) -o $(TERRAFORM_PLUGIN_DIR)/terraform-provisioner-ansible && chmod +x $(TERRAFORM_PLUGIN_DIR)/terraform-provisioner-ansible)
 
-qemu-user:
+qemu-security:
 	sed -i 's/\#user = \"root\"/user = \"root\"/g' /etc/libvirt/qemu.conf
 	sed -i 's/\#group = \"root\"/group = \"root\"/g' /etc/libvirt/qemu.conf
 	sed -i 's/\#security_driver = \"selinux\"/security_driver = \"none\"/g' /etc/libvirt/qemu.conf

--- a/2022_07_15-traefik-load-balancing/ansible/post_install.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/post_install.yml
@@ -1,0 +1,5 @@
+- hosts: all
+  roles:
+    - role: base
+  tags:
+    - base

--- a/2022_07_15-traefik-load-balancing/ansible/roles/base/handlers/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/base/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: Reboot
+  include_tasks: tasks/reboot.yml

--- a/2022_07_15-traefik-load-balancing/ansible/roles/base/tasks/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/base/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_tasks: network.yml

--- a/2022_07_15-traefik-load-balancing/ansible/roles/base/tasks/network.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/base/tasks/network.yml
@@ -1,0 +1,13 @@
+- name: Configure /etc/network/interfaces
+  template:
+    src: interfaces.j2
+    dest: /etc/network/interfaces
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reboot
+
+- name: Configure hostname
+  hostname:
+    name: "{{host_name}}"
+  notify: Reboot

--- a/2022_07_15-traefik-load-balancing/ansible/roles/base/tasks/reboot.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/base/tasks/reboot.yml
@@ -1,0 +1,12 @@
+- name: Attempting reboot
+  shell: reboot
+  async: 60
+  poll: 0
+
+- set_fact:
+    ansible_host: "{{host_ip}}"
+
+- name: Waiting for resurection
+  wait_for_connection:
+    delay: 60
+    timeout: 300

--- a/2022_07_15-traefik-load-balancing/ansible/roles/base/templates/interfaces.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/base/templates/interfaces.j2
@@ -1,0 +1,18 @@
+# MANAGED BY ANSIBLE
+
+source /etc/network/interfaces.d/*
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+auto {{ansible_default_ipv4['interface']}}
+iface {{ansible_default_ipv4['interface']}} inet static
+	address {{host_ip}}
+	netmask {{mask}}
+	gateway {{gateway}}
+	# dns-* options are implemented by the resolvconf package, if installed
+	dns-nameservers {{nameserver}}
+	dns-search traefik.local
+	dns-domain traefik.local

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/defaults/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/defaults/main.yml
@@ -1,0 +1,3 @@
+local_as: 64512
+vip: "N/A"
+anycast_healthchecker_version: 0.9.1

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/handlers/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/handlers/main.yml
@@ -1,0 +1,15 @@
+- name: Restart bird
+  systemd:
+    name: bird
+    state: restarted
+
+- name: Restart networking
+  systemd:
+    name: networking
+    state: restarted
+
+- name: Restart anycast-healthchecker
+  systemd:
+    name: anycast-healthchecker
+    state: restarted
+    daemon_reload: yes

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/config.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/config.yml
@@ -1,0 +1,8 @@
+- name: Configure bird
+  template:
+    src: "bird.conf-{{role}}.j2"
+    dest: /etc/bird/bird.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart bird

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/config_client.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/config_client.yml
@@ -1,0 +1,17 @@
+- name: Create config file
+  template:
+    src: anycast-healthchecker.conf.j2
+    dest: /etc/anycast-healthchecker.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart anycast-healthchecker
+
+- name: Create check file
+  template:
+    src: traefik.conf.j2
+    dest: /etc/anycast-healthchecker.d/traefik.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart anycast-healthchecker

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/install.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/install.yml
@@ -1,0 +1,5 @@
+- name: Install bird
+  apt:
+    name:
+      - bird
+    state: present

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/install_client.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/install_client.yml
@@ -1,0 +1,61 @@
+- name: Install pip
+  apt:
+    name:
+      - curl
+      - python3-pip
+      - python-setuptools
+    state: present
+
+- name: Install anycast health checker
+  pip:
+    executable: pip3
+    name: "anycast-healthchecker=={{anycast_healthchecker_version}}"
+
+- name: Create needed dir
+  file:
+    path: "{{item}}"
+    owner: bird
+    group: bird
+    mode: '0700'
+    state: directory
+  with_items:
+    - /var/lib/anycast-healthchecker/
+    - /etc/anycast-healthchecker.d
+    - /etc/bird.d
+
+- name: Check anycast-prefixes.conf exists or not
+  stat:
+    path: /var/lib/anycast-healthchecker/anycast-prefixes.conf
+  register: st
+
+- name: Default anycast-prefixes.conf file
+  template:
+    src: anycast-prefixes.conf.j2
+    dest: /var/lib/anycast-healthchecker/anycast-prefixes.conf
+    owner: bird
+    group: bird
+    mode: '0600'
+  when: not st.stat.exists
+
+- name: Create function anycast-vip
+  template:
+    src: anycast-vip.conf.j2
+    dest: /etc/bird.d/anycast-vip.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Create symlink
+  file:
+    src: /var/lib/anycast-healthchecker/anycast-prefixes.conf
+    dest: /etc/bird.d/anycast-prefixes.conf
+    state: link
+
+- name: Install systemd unit file
+  template:
+    src: anycast-healthchecker.service.j2
+    dest: /etc/systemd/system/anycast-healthchecker.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart anycast-healthchecker

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/main.yml
@@ -1,0 +1,11 @@
+- include_tasks: install.yml
+- include_tasks: "sysctl_{{role}}.yml"
+- include_tasks: install_client.yml
+  when: role == "client"
+- include_tasks: vipinterface.yml
+  when: role == "client"
+- include_tasks: config.yml
+- include_tasks: config_client.yml
+  when: role == "client"
+- include_tasks: service_client.yml
+  when: role == "client"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/service_client.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/service_client.yml
@@ -1,0 +1,5 @@
+- name: Start anycast-healthchecker
+  systemd:
+    name: anycast-healthchecker
+    state: started
+    enabled: yes

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/sysctl_client.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/sysctl_client.yml
@@ -1,0 +1,11 @@
+- name: Tune sysctl
+  sysctl:
+    name: '{{item.name}}'
+    value: '{{item.value}}'
+    sysctl_file: /etc/sysctl.d/traefik.conf
+    state: present
+  with_items:
+    - name: net.ipv4.conf.all.arp_ignore
+      value: '1'
+    - name: net.ipv4.conf.all.arp_announce
+      value: '8'

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/sysctl_router.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/sysctl_router.yml
@@ -1,0 +1,11 @@
+- name: Tune sysctl
+  sysctl:
+    name: '{{item.name}}'
+    value: '{{item.value}}'
+    sysctl_file: /etc/sysctl.d/traefik.conf
+    state: present
+  with_items:
+    - name: net.ipv4.ip_forward
+      value: '1'
+    - name: net.ipv4.fib_multipath_hash_policy
+      value: '1'

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/vipinterface.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/tasks/vipinterface.yml
@@ -1,0 +1,8 @@
+- name: Add VIP interface
+  template:
+    src: loopback-anycast.j2
+    dest: /etc/network/interfaces.d/lo:traefik
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart networking

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/anycast-healthchecker.conf.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/anycast-healthchecker.conf.j2
@@ -1,0 +1,21 @@
+[DEFAULT]
+interface             = lo
+
+[daemon]
+pidfile               = /var/run/anycast-healthchecker/anycast-healthchecker.pid
+ipv4                  = true
+ipv6                  = false
+bird_conf             = /var/lib/anycast-healthchecker/anycast-prefixes.conf
+bird_variable         = ACAST_PS_ADVERTISE
+bird_reconfigure_cmd  = /usr/sbin/birdc configure
+dummy_ip_prefix       = 127.0.0.1/32
+bird_keep_changes     = false
+bird_changes_counter  = 128
+purge_ip_prefixes     = false
+loglevel              = debug
+log_maxbytes          = 104857600
+log_backups           = 8
+log_server_port       = 514
+json_stdout           = false
+json_log_file         = false
+json_log_server       = false

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/anycast-healthchecker.service.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/anycast-healthchecker.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=Anycast healthchecker
+After=network.target
+Requires=network.target
+Documentation=https://github.com/unixsurfer/anycast_healthchecker/blob/master/README.rst
+
+[Service]
+Type=simple
+TimeoutStartSec=0
+User=bird
+Group=bird
+ExecStart=/usr/local/bin/anycast-healthchecker
+Restart=on-failure
+RuntimeDirectory=anycast-healthchecker
+
+[Install]
+WantedBy=multi-user.target

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/anycast-prefixes.conf.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/anycast-prefixes.conf.j2
@@ -1,0 +1,4 @@
+define ACAST_PS_ADVERTISE =
+    [
+        {{vip | ipaddr('address')}}/32
+    ];

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/anycast-vip.conf.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/anycast-vip.conf.j2
@@ -1,0 +1,4 @@
+function anycast_vip()
+{
+    return net ~ ACAST_PS_ADVERTISE;
+}

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/bird.conf-client.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/bird.conf-client.j2
@@ -1,0 +1,64 @@
+# Configure logging
+log syslog { debug, trace, info, remote, warning, error, auth, fatal, bug };
+log stderr all;
+
+# for anycast-healthchecker
+include "/etc/bird.d/*.conf";
+
+# Override router ID
+router id {{ansible_default_ipv4.address}};
+
+# do not import static routes for RR into the kernel
+filter import_kernel {
+  if source = RTS_STATIC then reject;
+  if ( net != 0.0.0.0/0 ) then {
+     accept;
+  }
+  reject;
+}
+
+# and do RR static routes also
+filter export_kernel {
+  if source = RTS_STATIC then reject;
+  if ( net != 0.0.0.0/0 ) then {
+    accept;
+  }
+}
+
+# Turn on global debugging of all protocols
+debug protocols all;
+
+# This pseudo-protocol watches all interface up/down events.
+protocol device {
+  scan time 2;    # Scan interfaces every 2 seconds
+}
+
+protocol kernel {
+  import filter import_kernel;
+  export filter export_kernel;
+}
+
+protocol direct direct1 {
+  interface "lo";
+  debug off;
+  export none;
+  import all;
+}
+
+template bgp company_router {
+  local as {{local_as}};
+  direct;
+  graceful restart;
+  import none;
+  export where anycast_vip();
+}
+
+{% for host in groups['bird'] %}
+{% if hostvars[host]['role'] == 'router' %}
+protocol bgp {{hostvars[host]['ansible_hostname']|replace('-', '_')}} from company_router {
+  description "{{hostvars[host]['ansible_hostname']}}@{{hostvars[host]['ansible_default_ipv4']['address']}}";
+  neighbor {{hostvars[host]['ansible_default_ipv4']['address']}} as {{local_as}};
+}
+
+{% endif %}
+{% endfor %}

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/bird.conf-router.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/bird.conf-router.j2
@@ -1,0 +1,39 @@
+# Configure logging
+log syslog { debug, trace, info, remote, warning, error, auth, fatal, bug };
+log stderr all;
+
+# Override router ID
+router id {{ansible_default_ipv4.address}};
+
+protocol kernel {
+  persist;
+  import none;
+  export all;
+  merge paths on;
+}
+
+# Turn on global debugging of all protocols
+debug protocols all;
+
+# This pseudo-protocol watches all interface up/down events.
+protocol device {
+  scan time 2;    # Scan interfaces every 2 seconds
+}
+
+template bgp traefik_lb {
+  local as {{local_as}};
+  direct;
+  graceful restart;
+  import all;
+  export none;
+}
+
+{% for host in groups['bird'] %}
+{% if hostvars[host]['role'] != 'router' %}
+protocol bgp {{hostvars[host]['ansible_hostname']|replace('-', '_')}} from traefik_lb {
+  description "{{hostvars[host]['ansible_hostname']}}@{{hostvars[host]['ansible_default_ipv4']['address']}}";
+  neighbor {{hostvars[host]['ansible_default_ipv4']['address']}} as {{local_as}};
+}
+
+{% endif %}
+{% endfor %}

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/loopback-anycast.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/loopback-anycast.j2
@@ -1,0 +1,4 @@
+auto lo:traefik
+iface lo:traefik inet static
+    address {{vip | ipaddr('address')}}
+    netmask 255.255.255.255

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/traefik.chk.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/traefik.chk.j2
@@ -1,0 +1,9 @@
+[traefik]
+check_cmd         = /usr/bin/curl --fail --silent http://{{vip | ipaddr('address')}}:8080/
+check_interval    = 10
+check_timeout     = 2
+check_fail        = 2
+check_rise        = 2
+check_disabled    = false
+on_disabled       = withdraw
+ip_prefix         = {{vip | ipaddr('address')}}/32

--- a/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/traefik.conf.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/bird/templates/traefik.conf.j2
@@ -1,0 +1,9 @@
+[traefik]
+check_cmd         = /usr/bin/curl --fail --silent http://{{vip | ipaddr('address')}}:8080/ -t 1
+check_interval    = 2
+check_timeout     = 1
+check_fail        = 2
+check_rise        = 2
+check_disabled    = false
+on_disabled       = withdraw
+ip_prefix         = {{vip | ipaddr('address')}}/32

--- a/2022_07_15-traefik-load-balancing/ansible/roles/fake-service/files/hostname.socket
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/fake-service/files/hostname.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=hostname service
+
+[Socket]
+ListenStream=127.0.0.1:8888
+Accept=yes
+
+[Install]
+WantedBy=sockets.target

--- a/2022_07_15-traefik-load-balancing/ansible/roles/fake-service/files/hostname@.service
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/fake-service/files/hostname@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=hostname connection handler
+
+[Service]
+ExecStart=/bin/bash -c "echo -e \"HTTP/1.0 200 OK\nContent-Type: text/plain\nContent-Length: $(/usr/bin/hostname | wc -c)\n\n$(/usr/bin/hostname)\"; sleep 0.5"
+User=www-data
+Group=www-data
+StandardInput=socket

--- a/2022_07_15-traefik-load-balancing/ansible/roles/fake-service/handlers/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/fake-service/handlers/main.yml
@@ -1,0 +1,8 @@
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+
+- name: Restart fake-service
+  systemd:
+    state: restarted
+    name: hostname.socket

--- a/2022_07_15-traefik-load-balancing/ansible/roles/fake-service/tasks/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/fake-service/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Install systemd xinetd like service
+  copy:
+    src: "{{item }}"
+    dest: "/etc/systemd/system/{{item}}"
+    owner: root
+    group: root
+    mode: '0644'
+  with_items:
+    - hostname.socket
+    - hostname@.service
+  notify:
+    - Reload systemd
+    - Restart fake-service
+
+- name: Start the fake-service
+  systemd:
+    state: started
+    daemon_reload: yes
+    name: hostname.socket
+    enabled: yes

--- a/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/handlers/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart keepalived
+  systemd:
+    name: keepalived
+    state: restarted

--- a/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/tasks/config.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/tasks/config.yml
@@ -1,0 +1,8 @@
+- name: Configure keepalived
+  template:
+    src: keepalived.conf.j2
+    dest: /etc/keepalived/keepalived.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart keepalived

--- a/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/tasks/install.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/tasks/install.yml
@@ -1,0 +1,6 @@
+- name: Install keepalived and curl
+  apt:
+    name:
+      - keepalived
+      - curl # curl is useful for keepalived check
+    state: present

--- a/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/tasks/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/tasks/main.yml
@@ -1,0 +1,3 @@
+- include_tasks: install.yml
+- include_tasks: config.yml
+- include_tasks: service.yml

--- a/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/tasks/service.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/tasks/service.yml
@@ -1,0 +1,4 @@
+- name: Start keepalived
+  systemd:
+    name: keepalived
+    state: started

--- a/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/templates/keepalived.conf.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/keepalived/templates/keepalived.conf.j2
@@ -1,0 +1,49 @@
+global_defs {
+        script_user nobody
+        enable_script_security
+}
+
+vrrp_script check_traefik {
+  script       "/usr/bin/curl --fail http://127.0.0.1:8080/ -t 1"
+  interval 2   # check every 2 seconds
+  fall 2       # require 2 failures for KO
+  rise 2       # require 2 successes for OK
+}
+
+{% if role == "master" %}
+vrrp_instance VI_traefik {
+        state MASTER
+        interface {{ansible_default_ipv4["interface"]}}
+        virtual_router_id {{keepalived_router_id}}
+        priority 255
+        advert_int 1
+        authentication {
+              auth_type AH
+              auth_pass {{keepalived_pass}}
+        }
+        virtual_ipaddress {
+              {{vip}}
+        }
+
+{% if keepalived_check is defined %}
+        track_script {
+               {{keepalived_check}}
+        }
+{% endif %}
+}
+{% else %}
+vrrp_instance VI_traefik {
+        state BACKUP
+        interface {{ansible_default_ipv4["interface"]}}
+        virtual_router_id {{keepalived_router_id}}
+        priority 254
+        advert_int 1
+        authentication {
+              auth_type AH
+              auth_pass {{keepalived_pass}}
+        }
+        virtual_ipaddress {
+              {{vip}}
+        }
+}
+{% endif %}

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes-config/files/crds.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes-config/files/crds.yml
@@ -1,0 +1,2264 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: ingressroutes.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  names:
+    kind: IngressRoute
+    listKind: IngressRouteList
+    plural: ingressroutes
+    singular: ingressroute
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressRouteSpec defines the desired state of IngressRoute.
+            properties:
+              entryPoints:
+                description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.8/routing/entrypoints/
+                  Default: all.'
+                items:
+                  type: string
+                type: array
+              routes:
+                description: Routes defines the list of routes.
+                items:
+                  description: Route holds the HTTP route configuration.
+                  properties:
+                    kind:
+                      description: Kind defines the kind of the route. Rule is the
+                        only supported kind.
+                      enum:
+                      - Rule
+                      type: string
+                    match:
+                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#rule'
+                      type: string
+                    middlewares:
+                      description: 'Middlewares defines the list of references to
+                        Middleware resources. More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-middleware'
+                      items:
+                        description: MiddlewareRef is a reference to a Middleware
+                          resource.
+                        properties:
+                          name:
+                            description: Name defines the name of the referenced Middleware
+                              resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Middleware resource.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    priority:
+                      description: 'Priority defines the router''s priority. More
+                        info: https://doc.traefik.io/traefik/v2.8/routing/routers/#priority'
+                      type: integer
+                    services:
+                      description: Services defines the list of Service. It can contain
+                        any combination of TraefikService and/or reference to a Kubernetes
+                        Service.
+                      items:
+                        description: Service defines an upstream HTTP service to proxy
+                          traffic to.
+                        properties:
+                          kind:
+                            description: Kind defines the kind of the Service.
+                            enum:
+                            - Service
+                            - TraefikService
+                            type: string
+                          name:
+                            description: Name defines the name of the referenced Kubernetes
+                              Service or TraefikService. The differentiation between
+                              the two is specified in the Kind field.
+                            type: string
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Kubernetes Service or TraefikService.
+                            type: string
+                          passHostHeader:
+                            description: PassHostHeader defines whether the client
+                              Host header is forwarded to the upstream Kubernetes
+                              Service. By default, passHostHeader is true.
+                            type: boolean
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Port defines the port of a Kubernetes Service.
+                              This can be a reference to a named port.
+                            x-kubernetes-int-or-string: true
+                          responseForwarding:
+                            description: ResponseForwarding defines how Traefik forwards
+                              the response from the upstream Kubernetes Service to
+                              the client.
+                            properties:
+                              flushInterval:
+                                description: 'FlushInterval defines the interval,
+                                  in milliseconds, in between flushes to the client
+                                  while copying the response body. A negative value
+                                  means to flush immediately after each write to the
+                                  client. This configuration is ignored when ReverseProxy
+                                  recognizes a response as a streaming response; for
+                                  such responses, writes are flushed to the client
+                                  immediately. Default: 100ms'
+                                type: string
+                            type: object
+                          scheme:
+                            description: Scheme defines the scheme to use for the
+                              request to the upstream Kubernetes Service. It defaults
+                              to https when Kubernetes Service port is 443, http otherwise.
+                            type: string
+                          serversTransport:
+                            description: ServersTransport defines the name of ServersTransport
+                              resource to use. It allows to configure the transport
+                              between Traefik and your servers. Can only be used on
+                              a Kubernetes Service.
+                            type: string
+                          sticky:
+                            description: 'Sticky defines the sticky sessions configuration.
+                              More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                            properties:
+                              cookie:
+                                description: Cookie defines the sticky cookie configuration.
+                                properties:
+                                  httpOnly:
+                                    description: HTTPOnly defines whether the cookie
+                                      can be accessed by client-side APIs, such as
+                                      JavaScript.
+                                    type: boolean
+                                  name:
+                                    description: Name defines the Cookie name.
+                                    type: string
+                                  sameSite:
+                                    description: 'SameSite defines the same site policy.
+                                      More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                                    type: string
+                                  secure:
+                                    description: Secure defines whether the cookie
+                                      can only be transmitted over an encrypted connection
+                                      (i.e. HTTPS).
+                                    type: boolean
+                                type: object
+                            type: object
+                          strategy:
+                            description: Strategy defines the load balancing strategy
+                              between the servers. RoundRobin is the only supported
+                              value at the moment.
+                            type: string
+                          weight:
+                            description: Weight defines the weight and should only
+                              be specified when Name references a TraefikService object
+                              (and to be precise, one that embeds a Weighted Round
+                              Robin).
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - kind
+                  - match
+                  type: object
+                type: array
+              tls:
+                description: 'TLS defines the TLS configuration. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#tls'
+                properties:
+                  certResolver:
+                    description: 'CertResolver defines the name of the certificate
+                      resolver to use. Cert resolvers have to be configured in the
+                      static configuration. More info: https://doc.traefik.io/traefik/v2.8/https/acme/#certificate-resolvers'
+                    type: string
+                  domains:
+                    description: 'Domains defines the list of domains that will be
+                      used to issue certificates. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#domains'
+                    items:
+                      description: Domain holds a domain name with SANs.
+                      properties:
+                        main:
+                          description: Main defines the main domain name.
+                          type: string
+                        sans:
+                          description: SANs defines the subject alternative domain
+                            names.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  options:
+                    description: 'Options defines the reference to a TLSOption, that
+                      specifies the parameters of the TLS connection. If not defined,
+                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#tls-options'
+                    properties:
+                      name:
+                        description: 'Name defines the name of the referenced TLSOption.
+                          More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsoption'
+                        type: string
+                      namespace:
+                        description: 'Namespace defines the namespace of the referenced
+                          TLSOption. More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsoption'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  secretName:
+                    description: SecretName is the name of the referenced Kubernetes
+                      Secret to specify the certificate details.
+                    type: string
+                  store:
+                    description: Store defines the reference to the TLSStore, that
+                      will be used to store certificates. Please note that only `default`
+                      TLSStore can be used.
+                    properties:
+                      name:
+                        description: 'Name defines the name of the referenced TLSStore.
+                          More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsstore'
+                        type: string
+                      namespace:
+                        description: 'Namespace defines the namespace of the referenced
+                          TLSStore. More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-tlsstore'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+            required:
+            - routes
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: ingressroutetcps.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  names:
+    kind: IngressRouteTCP
+    listKind: IngressRouteTCPList
+    plural: ingressroutetcps
+    singular: ingressroutetcp
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressRouteTCPSpec defines the desired state of IngressRouteTCP.
+            properties:
+              entryPoints:
+                description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.8/routing/entrypoints/
+                  Default: all.'
+                items:
+                  type: string
+                type: array
+              routes:
+                description: Routes defines the list of routes.
+                items:
+                  description: RouteTCP holds the TCP route configuration.
+                  properties:
+                    match:
+                      description: 'Match defines the router''s rule. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#rule_1'
+                      type: string
+                    middlewares:
+                      description: Middlewares defines the list of references to MiddlewareTCP
+                        resources.
+                      items:
+                        description: ObjectReference is a generic reference to a Traefik
+                          resource.
+                        properties:
+                          name:
+                            description: Name defines the name of the referenced Traefik
+                              resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Traefik resource.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    priority:
+                      description: 'Priority defines the router''s priority. More
+                        info: https://doc.traefik.io/traefik/v2.8/routing/routers/#priority_1'
+                      type: integer
+                    services:
+                      description: Services defines the list of TCP services.
+                      items:
+                        description: ServiceTCP defines an upstream TCP service to
+                          proxy traffic to.
+                        properties:
+                          name:
+                            description: Name defines the name of the referenced Kubernetes
+                              Service.
+                            type: string
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Kubernetes Service.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Port defines the port of a Kubernetes Service.
+                              This can be a reference to a named port.
+                            x-kubernetes-int-or-string: true
+                          proxyProtocol:
+                            description: 'ProxyProtocol defines the PROXY protocol
+                              configuration. More info: https://doc.traefik.io/traefik/v2.8/routing/services/#proxy-protocol'
+                            properties:
+                              version:
+                                description: Version defines the PROXY Protocol version
+                                  to use.
+                                type: integer
+                            type: object
+                          terminationDelay:
+                            description: TerminationDelay defines the deadline that
+                              the proxy sets, after one of its connected peers indicates
+                              it has closed the writing capability of its connection,
+                              to close the reading capability as well, hence fully
+                              terminating the connection. It is a duration in milliseconds,
+                              defaulting to 100. A negative value means an infinite
+                              deadline (i.e. the reading capability is never closed).
+                            type: integer
+                          weight:
+                            description: Weight defines the weight used when balancing
+                              requests between multiple Kubernetes Service.
+                            type: integer
+                        required:
+                        - name
+                        - port
+                        type: object
+                      type: array
+                  required:
+                  - match
+                  type: object
+                type: array
+              tls:
+                description: 'TLS defines the TLS configuration on a layer 4 / TCP
+                  Route. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#tls_1'
+                properties:
+                  certResolver:
+                    description: 'CertResolver defines the name of the certificate
+                      resolver to use. Cert resolvers have to be configured in the
+                      static configuration. More info: https://doc.traefik.io/traefik/v2.8/https/acme/#certificate-resolvers'
+                    type: string
+                  domains:
+                    description: 'Domains defines the list of domains that will be
+                      used to issue certificates. More info: https://doc.traefik.io/traefik/v2.8/routing/routers/#domains'
+                    items:
+                      description: Domain holds a domain name with SANs.
+                      properties:
+                        main:
+                          description: Main defines the main domain name.
+                          type: string
+                        sans:
+                          description: SANs defines the subject alternative domain
+                            names.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                  options:
+                    description: 'Options defines the reference to a TLSOption, that
+                      specifies the parameters of the TLS connection. If not defined,
+                      the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#tls-options'
+                    properties:
+                      name:
+                        description: Name defines the name of the referenced Traefik
+                          resource.
+                        type: string
+                      namespace:
+                        description: Namespace defines the namespace of the referenced
+                          Traefik resource.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  passthrough:
+                    description: Passthrough defines whether a TLS router will terminate
+                      the TLS connection.
+                    type: boolean
+                  secretName:
+                    description: SecretName is the name of the referenced Kubernetes
+                      Secret to specify the certificate details.
+                    type: string
+                  store:
+                    description: Store defines the reference to the TLSStore, that
+                      will be used to store certificates. Please note that only `default`
+                      TLSStore can be used.
+                    properties:
+                      name:
+                        description: Name defines the name of the referenced Traefik
+                          resource.
+                        type: string
+                      namespace:
+                        description: Namespace defines the namespace of the referenced
+                          Traefik resource.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+            required:
+            - routes
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: ingressrouteudps.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  names:
+    kind: IngressRouteUDP
+    listKind: IngressRouteUDPList
+    plural: ingressrouteudps
+    singular: ingressrouteudp
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressRouteUDPSpec defines the desired state of a IngressRouteUDP.
+            properties:
+              entryPoints:
+                description: 'EntryPoints defines the list of entry point names to
+                  bind to. Entry points have to be configured in the static configuration.
+                  More info: https://doc.traefik.io/traefik/v2.8/routing/entrypoints/
+                  Default: all.'
+                items:
+                  type: string
+                type: array
+              routes:
+                description: Routes defines the list of routes.
+                items:
+                  description: RouteUDP holds the UDP route configuration.
+                  properties:
+                    services:
+                      description: Services defines the list of UDP services.
+                      items:
+                        description: ServiceUDP defines an upstream UDP service to
+                          proxy traffic to.
+                        properties:
+                          name:
+                            description: Name defines the name of the referenced Kubernetes
+                              Service.
+                            type: string
+                          namespace:
+                            description: Namespace defines the namespace of the referenced
+                              Kubernetes Service.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Port defines the port of a Kubernetes Service.
+                              This can be a reference to a named port.
+                            x-kubernetes-int-or-string: true
+                          weight:
+                            description: Weight defines the weight used when balancing
+                              requests between multiple Kubernetes Service.
+                            type: integer
+                        required:
+                        - name
+                        - port
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            required:
+            - routes
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: middlewares.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  names:
+    kind: Middleware
+    listKind: MiddlewareList
+    plural: middlewares
+    singular: middleware
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'Middleware is the CRD implementation of a Traefik Middleware.
+          More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/overview/'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MiddlewareSpec defines the desired state of a Middleware.
+            properties:
+              addPrefix:
+                description: 'AddPrefix holds the add prefix middleware configuration.
+                  This middleware updates the path of a request before forwarding
+                  it. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/addprefix/'
+                properties:
+                  prefix:
+                    description: Prefix is the string to add before the current path
+                      in the requested URL. It should include a leading slash (/).
+                    type: string
+                type: object
+              basicAuth:
+                description: 'BasicAuth holds the basic auth middleware configuration.
+                  This middleware restricts access to your services to known users.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/basicauth/'
+                properties:
+                  headerField:
+                    description: 'HeaderField defines a header field to store the
+                      authenticated user. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/basicauth/#headerfield'
+                    type: string
+                  realm:
+                    description: 'Realm allows the protected resources on a server
+                      to be partitioned into a set of protection spaces, each with
+                      its own authentication scheme. Default: traefik.'
+                    type: string
+                  removeHeader:
+                    description: 'RemoveHeader sets the removeHeader option to true
+                      to remove the authorization header before forwarding the request
+                      to your service. Default: false.'
+                    type: boolean
+                  secret:
+                    description: Secret is the name of the referenced Kubernetes Secret
+                      containing user credentials.
+                    type: string
+                type: object
+              buffering:
+                description: 'Buffering holds the buffering middleware configuration.
+                  This middleware retries or limits the size of requests that can
+                  be forwarded to backends. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/buffering/#maxrequestbodybytes'
+                properties:
+                  maxRequestBodyBytes:
+                    description: 'MaxRequestBodyBytes defines the maximum allowed
+                      body size for the request (in bytes). If the request exceeds
+                      the allowed size, it is not forwarded to the service, and the
+                      client gets a 413 (Request Entity Too Large) response. Default:
+                      0 (no maximum).'
+                    format: int64
+                    type: integer
+                  maxResponseBodyBytes:
+                    description: 'MaxResponseBodyBytes defines the maximum allowed
+                      response size from the service (in bytes). If the response exceeds
+                      the allowed size, it is not forwarded to the client. The client
+                      gets a 500 (Internal Server Error) response instead. Default:
+                      0 (no maximum).'
+                    format: int64
+                    type: integer
+                  memRequestBodyBytes:
+                    description: 'MemRequestBodyBytes defines the threshold (in bytes)
+                      from which the request will be buffered on disk instead of in
+                      memory. Default: 1048576 (1Mi).'
+                    format: int64
+                    type: integer
+                  memResponseBodyBytes:
+                    description: 'MemResponseBodyBytes defines the threshold (in bytes)
+                      from which the response will be buffered on disk instead of
+                      in memory. Default: 1048576 (1Mi).'
+                    format: int64
+                    type: integer
+                  retryExpression:
+                    description: 'RetryExpression defines the retry conditions. It
+                      is a logical combination of functions with operators AND (&&)
+                      and OR (||). More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/buffering/#retryexpression'
+                    type: string
+                type: object
+              chain:
+                description: 'Chain holds the configuration of the chain middleware.
+                  This middleware enables to define reusable combinations of other
+                  pieces of middleware. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/chain/'
+                properties:
+                  middlewares:
+                    description: Middlewares is the list of MiddlewareRef which composes
+                      the chain.
+                    items:
+                      description: MiddlewareRef is a reference to a Middleware resource.
+                      properties:
+                        name:
+                          description: Name defines the name of the referenced Middleware
+                            resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Middleware resource.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              circuitBreaker:
+                description: CircuitBreaker holds the circuit breaker configuration.
+                properties:
+                  checkPeriod:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: CheckPeriod is the interval between successive checks
+                      of the circuit breaker condition (when in standby state).
+                    x-kubernetes-int-or-string: true
+                  expression:
+                    description: Expression is the condition that triggers the tripped
+                      state.
+                    type: string
+                  fallbackDuration:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: FallbackDuration is the duration for which the circuit
+                      breaker will wait before trying to recover (from a tripped state).
+                    x-kubernetes-int-or-string: true
+                  recoveryDuration:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: RecoveryDuration is the duration for which the circuit
+                      breaker will try to recover (as soon as it is in recovering
+                      state).
+                    x-kubernetes-int-or-string: true
+                type: object
+              compress:
+                description: 'Compress holds the compress middleware configuration.
+                  This middleware compresses responses before sending them to the
+                  client, using gzip compression. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/compress/'
+                properties:
+                  excludedContentTypes:
+                    description: ExcludedContentTypes defines the list of content
+                      types to compare the Content-Type header of the incoming requests
+                      and responses before compressing.
+                    items:
+                      type: string
+                    type: array
+                  minResponseBodyBytes:
+                    description: 'MinResponseBodyBytes defines the minimum amount
+                      of bytes a response body must have to be compressed. Default:
+                      1024.'
+                    type: integer
+                type: object
+              contentType:
+                description: ContentType holds the content-type middleware configuration.
+                  This middleware exists to enable the correct behavior until at least
+                  the default one can be changed in a future version.
+                properties:
+                  autoDetect:
+                    description: AutoDetect specifies whether to let the `Content-Type`
+                      header, if it has not been set by the backend, be automatically
+                      set to a value derived from the contents of the response. As
+                      a proxy, the default behavior should be to leave the header
+                      alone, regardless of what the backend did with it. However,
+                      the historic default was to always auto-detect and set the header
+                      if it was nil, and it is going to be kept that way in order
+                      to support users currently relying on it.
+                    type: boolean
+                type: object
+              digestAuth:
+                description: 'DigestAuth holds the digest auth middleware configuration.
+                  This middleware restricts access to your services to known users.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/digestauth/'
+                properties:
+                  headerField:
+                    description: 'HeaderField defines a header field to store the
+                      authenticated user. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/basicauth/#headerfield'
+                    type: string
+                  realm:
+                    description: 'Realm allows the protected resources on a server
+                      to be partitioned into a set of protection spaces, each with
+                      its own authentication scheme. Default: traefik.'
+                    type: string
+                  removeHeader:
+                    description: RemoveHeader defines whether to remove the authorization
+                      header before forwarding the request to the backend.
+                    type: boolean
+                  secret:
+                    description: Secret is the name of the referenced Kubernetes Secret
+                      containing user credentials.
+                    type: string
+                type: object
+              errors:
+                description: 'ErrorPage holds the custom error middleware configuration.
+                  This middleware returns a custom page in lieu of the default, according
+                  to configured ranges of HTTP Status codes. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/errorpages/'
+                properties:
+                  query:
+                    description: Query defines the URL for the error page (hosted
+                      by service). The {status} variable can be used in order to insert
+                      the status code in the URL.
+                    type: string
+                  service:
+                    description: 'Service defines the reference to a Kubernetes Service
+                      that will serve the error page. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/errorpages/#service'
+                    properties:
+                      kind:
+                        description: Kind defines the kind of the Service.
+                        enum:
+                        - Service
+                        - TraefikService
+                        type: string
+                      name:
+                        description: Name defines the name of the referenced Kubernetes
+                          Service or TraefikService. The differentiation between the
+                          two is specified in the Kind field.
+                        type: string
+                      namespace:
+                        description: Namespace defines the namespace of the referenced
+                          Kubernetes Service or TraefikService.
+                        type: string
+                      passHostHeader:
+                        description: PassHostHeader defines whether the client Host
+                          header is forwarded to the upstream Kubernetes Service.
+                          By default, passHostHeader is true.
+                        type: boolean
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Port defines the port of a Kubernetes Service.
+                          This can be a reference to a named port.
+                        x-kubernetes-int-or-string: true
+                      responseForwarding:
+                        description: ResponseForwarding defines how Traefik forwards
+                          the response from the upstream Kubernetes Service to the
+                          client.
+                        properties:
+                          flushInterval:
+                            description: 'FlushInterval defines the interval, in milliseconds,
+                              in between flushes to the client while copying the response
+                              body. A negative value means to flush immediately after
+                              each write to the client. This configuration is ignored
+                              when ReverseProxy recognizes a response as a streaming
+                              response; for such responses, writes are flushed to
+                              the client immediately. Default: 100ms'
+                            type: string
+                        type: object
+                      scheme:
+                        description: Scheme defines the scheme to use for the request
+                          to the upstream Kubernetes Service. It defaults to https
+                          when Kubernetes Service port is 443, http otherwise.
+                        type: string
+                      serversTransport:
+                        description: ServersTransport defines the name of ServersTransport
+                          resource to use. It allows to configure the transport between
+                          Traefik and your servers. Can only be used on a Kubernetes
+                          Service.
+                        type: string
+                      sticky:
+                        description: 'Sticky defines the sticky sessions configuration.
+                          More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                        properties:
+                          cookie:
+                            description: Cookie defines the sticky cookie configuration.
+                            properties:
+                              httpOnly:
+                                description: HTTPOnly defines whether the cookie can
+                                  be accessed by client-side APIs, such as JavaScript.
+                                type: boolean
+                              name:
+                                description: Name defines the Cookie name.
+                                type: string
+                              sameSite:
+                                description: 'SameSite defines the same site policy.
+                                  More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                                type: string
+                              secure:
+                                description: Secure defines whether the cookie can
+                                  only be transmitted over an encrypted connection
+                                  (i.e. HTTPS).
+                                type: boolean
+                            type: object
+                        type: object
+                      strategy:
+                        description: Strategy defines the load balancing strategy
+                          between the servers. RoundRobin is the only supported value
+                          at the moment.
+                        type: string
+                      weight:
+                        description: Weight defines the weight and should only be
+                          specified when Name references a TraefikService object (and
+                          to be precise, one that embeds a Weighted Round Robin).
+                        type: integer
+                    required:
+                    - name
+                    type: object
+                  status:
+                    description: Status defines which status or range of statuses
+                      should result in an error page. It can be either a status code
+                      as a number (500), as multiple comma-separated numbers (500,502),
+                      as ranges by separating two codes with a dash (500-599), or
+                      a combination of the two (404,418,500-599).
+                    items:
+                      type: string
+                    type: array
+                type: object
+              forwardAuth:
+                description: 'ForwardAuth holds the forward auth middleware configuration.
+                  This middleware delegates the request authentication to a Service.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/forwardauth/'
+                properties:
+                  address:
+                    description: Address defines the authentication server address.
+                    type: string
+                  authRequestHeaders:
+                    description: AuthRequestHeaders defines the list of the headers
+                      to copy from the request to the authentication server. If not
+                      set or empty then all request headers are passed.
+                    items:
+                      type: string
+                    type: array
+                  authResponseHeaders:
+                    description: AuthResponseHeaders defines the list of headers to
+                      copy from the authentication server response and set on forwarded
+                      request, replacing any existing conflicting headers.
+                    items:
+                      type: string
+                    type: array
+                  authResponseHeadersRegex:
+                    description: 'AuthResponseHeadersRegex defines the regex to match
+                      headers to copy from the authentication server response and
+                      set on forwarded request, after stripping all headers that match
+                      the regex. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/forwardauth/#authresponseheadersregex'
+                    type: string
+                  tls:
+                    description: TLS defines the configuration used to secure the
+                      connection to the authentication server.
+                    properties:
+                      caOptional:
+                        type: boolean
+                      caSecret:
+                        description: CASecret is the name of the referenced Kubernetes
+                          Secret containing the CA to validate the server certificate.
+                          The CA certificate is extracted from key `tls.ca` or `ca.crt`.
+                        type: string
+                      certSecret:
+                        description: CertSecret is the name of the referenced Kubernetes
+                          Secret containing the client certificate. The client certificate
+                          is extracted from the keys `tls.crt` and `tls.key`.
+                        type: string
+                      insecureSkipVerify:
+                        description: InsecureSkipVerify defines whether the server
+                          certificates should be validated.
+                        type: boolean
+                    type: object
+                  trustForwardHeader:
+                    description: 'TrustForwardHeader defines whether to trust (ie:
+                      forward) all X-Forwarded-* headers.'
+                    type: boolean
+                type: object
+              headers:
+                description: 'Headers holds the headers middleware configuration.
+                  This middleware manages the requests and responses headers. More
+                  info: https://doc.traefik.io/traefik/v2.8/middlewares/http/headers/#customrequestheaders'
+                properties:
+                  accessControlAllowCredentials:
+                    description: AccessControlAllowCredentials defines whether the
+                      request can include user credentials.
+                    type: boolean
+                  accessControlAllowHeaders:
+                    description: AccessControlAllowHeaders defines the Access-Control-Request-Headers
+                      values sent in preflight response.
+                    items:
+                      type: string
+                    type: array
+                  accessControlAllowMethods:
+                    description: AccessControlAllowMethods defines the Access-Control-Request-Method
+                      values sent in preflight response.
+                    items:
+                      type: string
+                    type: array
+                  accessControlAllowOriginList:
+                    description: AccessControlAllowOriginList is a list of allowable
+                      origins. Can also be a wildcard origin "*".
+                    items:
+                      type: string
+                    type: array
+                  accessControlAllowOriginListRegex:
+                    description: AccessControlAllowOriginListRegex is a list of allowable
+                      origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
+                    items:
+                      type: string
+                    type: array
+                  accessControlExposeHeaders:
+                    description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
+                      values sent in preflight response.
+                    items:
+                      type: string
+                    type: array
+                  accessControlMaxAge:
+                    description: AccessControlMaxAge defines the time that a preflight
+                      request may be cached.
+                    format: int64
+                    type: integer
+                  addVaryHeader:
+                    description: AddVaryHeader defines whether the Vary header is
+                      automatically added/updated when the AccessControlAllowOriginList
+                      is set.
+                    type: boolean
+                  allowedHosts:
+                    description: AllowedHosts defines the fully qualified list of
+                      allowed domain names.
+                    items:
+                      type: string
+                    type: array
+                  browserXssFilter:
+                    description: BrowserXSSFilter defines whether to add the X-XSS-Protection
+                      header with the value 1; mode=block.
+                    type: boolean
+                  contentSecurityPolicy:
+                    description: ContentSecurityPolicy defines the Content-Security-Policy
+                      header value.
+                    type: string
+                  contentTypeNosniff:
+                    description: ContentTypeNosniff defines whether to add the X-Content-Type-Options
+                      header with the nosniff value.
+                    type: boolean
+                  customBrowserXSSValue:
+                    description: CustomBrowserXSSValue defines the X-XSS-Protection
+                      header value. This overrides the BrowserXssFilter option.
+                    type: string
+                  customFrameOptionsValue:
+                    description: CustomFrameOptionsValue defines the X-Frame-Options
+                      header value. This overrides the FrameDeny option.
+                    type: string
+                  customRequestHeaders:
+                    additionalProperties:
+                      type: string
+                    description: CustomRequestHeaders defines the header names and
+                      values to apply to the request.
+                    type: object
+                  customResponseHeaders:
+                    additionalProperties:
+                      type: string
+                    description: CustomResponseHeaders defines the header names and
+                      values to apply to the response.
+                    type: object
+                  featurePolicy:
+                    description: 'Deprecated: use PermissionsPolicy instead.'
+                    type: string
+                  forceSTSHeader:
+                    description: ForceSTSHeader defines whether to add the STS header
+                      even when the connection is HTTP.
+                    type: boolean
+                  frameDeny:
+                    description: FrameDeny defines whether to add the X-Frame-Options
+                      header with the DENY value.
+                    type: boolean
+                  hostsProxyHeaders:
+                    description: HostsProxyHeaders defines the header keys that may
+                      hold a proxied hostname value for the request.
+                    items:
+                      type: string
+                    type: array
+                  isDevelopment:
+                    description: IsDevelopment defines whether to mitigate the unwanted
+                      effects of the AllowedHosts, SSL, and STS options when developing.
+                      Usually testing takes place using HTTP, not HTTPS, and on localhost,
+                      not your production domain. If you would like your development
+                      environment to mimic production with complete Host blocking,
+                      SSL redirects, and STS headers, leave this as false.
+                    type: boolean
+                  permissionsPolicy:
+                    description: PermissionsPolicy defines the Permissions-Policy
+                      header value. This allows sites to control browser features.
+                    type: string
+                  publicKey:
+                    description: PublicKey is the public key that implements HPKP
+                      to prevent MITM attacks with forged certificates.
+                    type: string
+                  referrerPolicy:
+                    description: ReferrerPolicy defines the Referrer-Policy header
+                      value. This allows sites to control whether browsers forward
+                      the Referer header to other sites.
+                    type: string
+                  sslForceHost:
+                    description: 'Deprecated: use RedirectRegex instead.'
+                    type: boolean
+                  sslHost:
+                    description: 'Deprecated: use RedirectRegex instead.'
+                    type: string
+                  sslProxyHeaders:
+                    additionalProperties:
+                      type: string
+                    description: 'SSLProxyHeaders defines the header keys with associated
+                      values that would indicate a valid HTTPS request. It can be
+                      useful when using other proxies (example: "X-Forwarded-Proto":
+                      "https").'
+                    type: object
+                  sslRedirect:
+                    description: 'Deprecated: use EntryPoint redirection or RedirectScheme
+                      instead.'
+                    type: boolean
+                  sslTemporaryRedirect:
+                    description: 'Deprecated: use EntryPoint redirection or RedirectScheme
+                      instead.'
+                    type: boolean
+                  stsIncludeSubdomains:
+                    description: STSIncludeSubdomains defines whether the includeSubDomains
+                      directive is appended to the Strict-Transport-Security header.
+                    type: boolean
+                  stsPreload:
+                    description: STSPreload defines whether the preload flag is appended
+                      to the Strict-Transport-Security header.
+                    type: boolean
+                  stsSeconds:
+                    description: STSSeconds defines the max-age of the Strict-Transport-Security
+                      header. If set to 0, the header is not set.
+                    format: int64
+                    type: integer
+                type: object
+              inFlightReq:
+                description: 'InFlightReq holds the in-flight request middleware configuration.
+                  This middleware limits the number of requests being processed and
+                  served concurrently. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/inflightreq/'
+                properties:
+                  amount:
+                    description: Amount defines the maximum amount of allowed simultaneous
+                      in-flight request. The middleware responds with HTTP 429 Too
+                      Many Requests if there are already amount requests in progress
+                      (based on the same sourceCriterion strategy).
+                    format: int64
+                    type: integer
+                  sourceCriterion:
+                    description: 'SourceCriterion defines what criterion is used to
+                      group requests as originating from a common source. If several
+                      strategies are defined at the same time, an error will be raised.
+                      If none are set, the default is to use the requestHost. More
+                      info: https://doc.traefik.io/traefik/v2.8/middlewares/http/inflightreq/#sourcecriterion'
+                    properties:
+                      ipStrategy:
+                        description: 'IPStrategy holds the IP strategy configuration
+                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/#ipstrategy'
+                        properties:
+                          depth:
+                            description: Depth tells Traefik to use the X-Forwarded-For
+                              header and take the IP located at the depth position
+                              (starting from the right).
+                            type: integer
+                          excludedIPs:
+                            description: ExcludedIPs configures Traefik to scan the
+                              X-Forwarded-For header and select the first IP not in
+                              the list.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      requestHeaderName:
+                        description: RequestHeaderName defines the name of the header
+                          used to group incoming requests.
+                        type: string
+                      requestHost:
+                        description: RequestHost defines whether to consider the request
+                          Host as the source.
+                        type: boolean
+                    type: object
+                type: object
+              ipWhiteList:
+                description: 'IPWhiteList holds the IP whitelist middleware configuration.
+                  This middleware accepts / refuses requests based on the client IP.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/'
+                properties:
+                  ipStrategy:
+                    description: 'IPStrategy holds the IP strategy configuration used
+                      by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/#ipstrategy'
+                    properties:
+                      depth:
+                        description: Depth tells Traefik to use the X-Forwarded-For
+                          header and take the IP located at the depth position (starting
+                          from the right).
+                        type: integer
+                      excludedIPs:
+                        description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
+                          header and select the first IP not in the list.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  sourceRange:
+                    description: SourceRange defines the set of allowed IPs (or ranges
+                      of allowed IPs by using CIDR notation).
+                    items:
+                      type: string
+                    type: array
+                type: object
+              passTLSClientCert:
+                description: 'PassTLSClientCert holds the pass TLS client cert middleware
+                  configuration. This middleware adds the selected data from the passed
+                  client TLS certificate to a header. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/passtlsclientcert/'
+                properties:
+                  info:
+                    description: Info selects the specific client certificate details
+                      you want to add to the X-Forwarded-Tls-Client-Cert-Info header.
+                    properties:
+                      issuer:
+                        description: Issuer defines the client certificate issuer
+                          details to add to the X-Forwarded-Tls-Client-Cert-Info header.
+                        properties:
+                          commonName:
+                            description: CommonName defines whether to add the organizationalUnit
+                              information into the issuer.
+                            type: boolean
+                          country:
+                            description: Country defines whether to add the country
+                              information into the issuer.
+                            type: boolean
+                          domainComponent:
+                            description: DomainComponent defines whether to add the
+                              domainComponent information into the issuer.
+                            type: boolean
+                          locality:
+                            description: Locality defines whether to add the locality
+                              information into the issuer.
+                            type: boolean
+                          organization:
+                            description: Organization defines whether to add the organization
+                              information into the issuer.
+                            type: boolean
+                          province:
+                            description: Province defines whether to add the province
+                              information into the issuer.
+                            type: boolean
+                          serialNumber:
+                            description: SerialNumber defines whether to add the serialNumber
+                              information into the issuer.
+                            type: boolean
+                        type: object
+                      notAfter:
+                        description: NotAfter defines whether to add the Not After
+                          information from the Validity part.
+                        type: boolean
+                      notBefore:
+                        description: NotBefore defines whether to add the Not Before
+                          information from the Validity part.
+                        type: boolean
+                      sans:
+                        description: Sans defines whether to add the Subject Alternative
+                          Name information from the Subject Alternative Name part.
+                        type: boolean
+                      serialNumber:
+                        description: SerialNumber defines whether to add the client
+                          serialNumber information.
+                        type: boolean
+                      subject:
+                        description: Subject defines the client certificate subject
+                          details to add to the X-Forwarded-Tls-Client-Cert-Info header.
+                        properties:
+                          commonName:
+                            description: CommonName defines whether to add the organizationalUnit
+                              information into the subject.
+                            type: boolean
+                          country:
+                            description: Country defines whether to add the country
+                              information into the subject.
+                            type: boolean
+                          domainComponent:
+                            description: DomainComponent defines whether to add the
+                              domainComponent information into the subject.
+                            type: boolean
+                          locality:
+                            description: Locality defines whether to add the locality
+                              information into the subject.
+                            type: boolean
+                          organization:
+                            description: Organization defines whether to add the organization
+                              information into the subject.
+                            type: boolean
+                          organizationalUnit:
+                            description: OrganizationalUnit defines whether to add
+                              the organizationalUnit information into the subject.
+                            type: boolean
+                          province:
+                            description: Province defines whether to add the province
+                              information into the subject.
+                            type: boolean
+                          serialNumber:
+                            description: SerialNumber defines whether to add the serialNumber
+                              information into the subject.
+                            type: boolean
+                        type: object
+                    type: object
+                  pem:
+                    description: PEM sets the X-Forwarded-Tls-Client-Cert header with
+                      the escaped certificate.
+                    type: boolean
+                type: object
+              plugin:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: 'Plugin defines the middleware plugin configuration.
+                  More info: https://doc.traefik.io/traefik/plugins/'
+                type: object
+              rateLimit:
+                description: 'RateLimit holds the rate limit configuration. This middleware
+                  ensures that services will receive a fair amount of requests, and
+                  allows one to define what fair is. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ratelimit/'
+                properties:
+                  average:
+                    description: Average is the maximum rate, by default in requests/s,
+                      allowed for the given source. It defaults to 0, which means
+                      no rate limiting. The rate is actually defined by dividing Average
+                      by Period. So for a rate below 1req/s, one needs to define a
+                      Period larger than a second.
+                    format: int64
+                    type: integer
+                  burst:
+                    description: Burst is the maximum number of requests allowed to
+                      arrive in the same arbitrarily small period of time. It defaults
+                      to 1.
+                    format: int64
+                    type: integer
+                  period:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'Period, in combination with Average, defines the
+                      actual maximum rate, such as: r = Average / Period. It defaults
+                      to a second.'
+                    x-kubernetes-int-or-string: true
+                  sourceCriterion:
+                    description: SourceCriterion defines what criterion is used to
+                      group requests as originating from a common source. If several
+                      strategies are defined at the same time, an error will be raised.
+                      If none are set, the default is to use the request's remote
+                      address field (as an ipStrategy).
+                    properties:
+                      ipStrategy:
+                        description: 'IPStrategy holds the IP strategy configuration
+                          used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/ipwhitelist/#ipstrategy'
+                        properties:
+                          depth:
+                            description: Depth tells Traefik to use the X-Forwarded-For
+                              header and take the IP located at the depth position
+                              (starting from the right).
+                            type: integer
+                          excludedIPs:
+                            description: ExcludedIPs configures Traefik to scan the
+                              X-Forwarded-For header and select the first IP not in
+                              the list.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      requestHeaderName:
+                        description: RequestHeaderName defines the name of the header
+                          used to group incoming requests.
+                        type: string
+                      requestHost:
+                        description: RequestHost defines whether to consider the request
+                          Host as the source.
+                        type: boolean
+                    type: object
+                type: object
+              redirectRegex:
+                description: 'RedirectRegex holds the redirect regex middleware configuration.
+                  This middleware redirects a request using regex matching and replacement.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/redirectregex/#regex'
+                properties:
+                  permanent:
+                    description: Permanent defines whether the redirection is permanent
+                      (301).
+                    type: boolean
+                  regex:
+                    description: Regex defines the regex used to match and capture
+                      elements from the request URL.
+                    type: string
+                  replacement:
+                    description: Replacement defines how to modify the URL to have
+                      the new target URL.
+                    type: string
+                type: object
+              redirectScheme:
+                description: 'RedirectScheme holds the redirect scheme middleware
+                  configuration. This middleware redirects requests from a scheme/port
+                  to another. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/redirectscheme/'
+                properties:
+                  permanent:
+                    description: Permanent defines whether the redirection is permanent
+                      (301).
+                    type: boolean
+                  port:
+                    description: Port defines the port of the new URL.
+                    type: string
+                  scheme:
+                    description: Scheme defines the scheme of the new URL.
+                    type: string
+                type: object
+              replacePath:
+                description: 'ReplacePath holds the replace path middleware configuration.
+                  This middleware replaces the path of the request URL and store the
+                  original path in an X-Replaced-Path header. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/replacepath/'
+                properties:
+                  path:
+                    description: Path defines the path to use as replacement in the
+                      request URL.
+                    type: string
+                type: object
+              replacePathRegex:
+                description: 'ReplacePathRegex holds the replace path regex middleware
+                  configuration. This middleware replaces the path of a URL using
+                  regex matching and replacement. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/replacepathregex/'
+                properties:
+                  regex:
+                    description: Regex defines the regular expression used to match
+                      and capture the path from the request URL.
+                    type: string
+                  replacement:
+                    description: Replacement defines the replacement path format,
+                      which can include captured variables.
+                    type: string
+                type: object
+              retry:
+                description: 'Retry holds the retry middleware configuration. This
+                  middleware reissues requests a given number of times to a backend
+                  server if that server does not reply. As soon as the server answers,
+                  the middleware stops retrying, regardless of the response status.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/retry/'
+                properties:
+                  attempts:
+                    description: Attempts defines how many times the request should
+                      be retried.
+                    type: integer
+                  initialInterval:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: InitialInterval defines the first wait time in the
+                      exponential backoff series. The maximum interval is calculated
+                      as twice the initialInterval. If unspecified, requests will
+                      be retried immediately. The value of initialInterval should
+                      be provided in seconds or as a valid duration format, see https://pkg.go.dev/time#ParseDuration.
+                    x-kubernetes-int-or-string: true
+                type: object
+              stripPrefix:
+                description: 'StripPrefix holds the strip prefix middleware configuration.
+                  This middleware removes the specified prefixes from the URL path.
+                  More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/stripprefix/'
+                properties:
+                  forceSlash:
+                    description: 'ForceSlash ensures that the resulting stripped path
+                      is not the empty string, by replacing it with / when necessary.
+                      Default: true.'
+                    type: boolean
+                  prefixes:
+                    description: Prefixes defines the prefixes to strip from the request
+                      URL.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              stripPrefixRegex:
+                description: 'StripPrefixRegex holds the strip prefix regex middleware
+                  configuration. This middleware removes the matching prefixes from
+                  the URL path. More info: https://doc.traefik.io/traefik/v2.8/middlewares/http/stripprefixregex/'
+                properties:
+                  regex:
+                    description: Regex defines the regular expression to match the
+                      path prefix from the request URL.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: middlewaretcps.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  names:
+    kind: MiddlewareTCP
+    listKind: MiddlewareTCPList
+    plural: middlewaretcps
+    singular: middlewaretcp
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MiddlewareTCP is the CRD implementation of a Traefik TCP middleware.
+          More info: https://doc.traefik.io/traefik/v2.8/middlewares/overview/'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MiddlewareTCPSpec defines the desired state of a MiddlewareTCP.
+            properties:
+              inFlightConn:
+                description: InFlightConn defines the InFlightConn middleware configuration.
+                properties:
+                  amount:
+                    description: Amount defines the maximum amount of allowed simultaneous
+                      connections. The middleware closes the connection if there are
+                      already amount connections opened.
+                    format: int64
+                    type: integer
+                type: object
+              ipWhiteList:
+                description: IPWhiteList defines the IPWhiteList middleware configuration.
+                properties:
+                  sourceRange:
+                    description: SourceRange defines the allowed IPs (or ranges of
+                      allowed IPs by using CIDR notation).
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: serverstransports.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  names:
+    kind: ServersTransport
+    listKind: ServersTransportList
+    plural: serverstransports
+    singular: serverstransport
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'ServersTransport is the CRD implementation of a ServersTransport.
+          If no serversTransport is specified, the default@internal will be used.
+          The default@internal serversTransport is created from the static configuration.
+          More info: https://doc.traefik.io/traefik/v2.8/routing/services/#serverstransport_1'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServersTransportSpec defines the desired state of a ServersTransport.
+            properties:
+              certificatesSecrets:
+                description: CertificatesSecrets defines a list of secret storing
+                  client certificates for mTLS.
+                items:
+                  type: string
+                type: array
+              disableHTTP2:
+                description: DisableHTTP2 disables HTTP/2 for connections with backend
+                  servers.
+                type: boolean
+              forwardingTimeouts:
+                description: ForwardingTimeouts defines the timeouts for requests
+                  forwarded to the backend servers.
+                properties:
+                  dialTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: DialTimeout is the amount of time to wait until a
+                      connection to a backend server can be established.
+                    x-kubernetes-int-or-string: true
+                  idleConnTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: IdleConnTimeout is the maximum period for which an
+                      idle HTTP keep-alive connection will remain open before closing
+                      itself.
+                    x-kubernetes-int-or-string: true
+                  pingTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: PingTimeout is the timeout after which the HTTP/2
+                      connection will be closed if a response to ping is not received.
+                    x-kubernetes-int-or-string: true
+                  readIdleTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: ReadIdleTimeout is the timeout after which a health
+                      check using ping frame will be carried out if no frame is received
+                      on the HTTP/2 connection.
+                    x-kubernetes-int-or-string: true
+                  responseHeaderTimeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: ResponseHeaderTimeout is the amount of time to wait
+                      for a server's response headers after fully writing the request
+                      (including its body, if any).
+                    x-kubernetes-int-or-string: true
+                type: object
+              insecureSkipVerify:
+                description: InsecureSkipVerify disables SSL certificate verification.
+                type: boolean
+              maxIdleConnsPerHost:
+                description: MaxIdleConnsPerHost controls the maximum idle (keep-alive)
+                  to keep per-host.
+                type: integer
+              peerCertURI:
+                description: PeerCertURI defines the peer cert URI used to match against
+                  SAN URI during the peer certificate verification.
+                type: string
+              rootCAsSecrets:
+                description: RootCAsSecrets defines a list of CA secret used to validate
+                  self-signed certificate.
+                items:
+                  type: string
+                type: array
+              serverName:
+                description: ServerName defines the server name used to contact the
+                  server.
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: tlsoptions.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  names:
+    kind: TLSOption
+    listKind: TLSOptionList
+    plural: tlsoptions
+    singular: tlsoption
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'TLSOption is the CRD implementation of a Traefik TLS Option,
+          allowing to configure some parameters of the TLS connection. More info:
+          https://doc.traefik.io/traefik/v2.8/https/tls/#tls-options'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSOptionSpec defines the desired state of a TLSOption.
+            properties:
+              alpnProtocols:
+                description: 'ALPNProtocols defines the list of supported application
+                  level protocols for the TLS handshake, in order of preference. More
+                  info: https://doc.traefik.io/traefik/v2.8/https/tls/#alpn-protocols'
+                items:
+                  type: string
+                type: array
+              cipherSuites:
+                description: 'CipherSuites defines the list of supported cipher suites
+                  for TLS versions up to TLS 1.2. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#cipher-suites'
+                items:
+                  type: string
+                type: array
+              clientAuth:
+                description: ClientAuth defines the server's policy for TLS Client
+                  Authentication.
+                properties:
+                  clientAuthType:
+                    description: ClientAuthType defines the client authentication
+                      type to apply.
+                    enum:
+                    - NoClientCert
+                    - RequestClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - RequireAndVerifyClientCert
+                    type: string
+                  secretNames:
+                    description: SecretNames defines the names of the referenced Kubernetes
+                      Secret storing certificate details.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              curvePreferences:
+                description: 'CurvePreferences defines the preferred elliptic curves
+                  in a specific order. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#curve-preferences'
+                items:
+                  type: string
+                type: array
+              maxVersion:
+                description: 'MaxVersion defines the maximum TLS version that Traefik
+                  will accept. Possible values: VersionTLS10, VersionTLS11, VersionTLS12,
+                  VersionTLS13. Default: None.'
+                type: string
+              minVersion:
+                description: 'MinVersion defines the minimum TLS version that Traefik
+                  will accept. Possible values: VersionTLS10, VersionTLS11, VersionTLS12,
+                  VersionTLS13. Default: VersionTLS10.'
+                type: string
+              preferServerCipherSuites:
+                description: PreferServerCipherSuites defines whether the server chooses
+                  a cipher suite among his own instead of among the client's. It is
+                  enabled automatically when minVersion or maxVersion are set.
+                type: boolean
+              sniStrict:
+                description: SniStrict defines whether Traefik allows connections
+                  from clients connections that do not specify a server_name extension.
+                type: boolean
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: tlsstores.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  names:
+    kind: TLSStore
+    listKind: TLSStoreList
+    plural: tlsstores
+    singular: tlsstore
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'TLSStore is the CRD implementation of a Traefik TLS Store. For
+          the time being, only the TLSStore named default is supported. This means
+          that you cannot have two stores that are named default in different Kubernetes
+          namespaces. More info: https://doc.traefik.io/traefik/v2.8/https/tls/#certificates-stores'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSStoreSpec defines the desired state of a TLSStore.
+            properties:
+              certificates:
+                description: Certificates is a list of secret names, each secret holding
+                  a key/certificate pair to add to the store.
+                items:
+                  description: Certificate holds a secret name for the TLSStore resource.
+                  properties:
+                    secretName:
+                      description: SecretName is the name of the referenced Kubernetes
+                        Secret to specify the certificate details.
+                      type: string
+                  required:
+                  - secretName
+                  type: object
+                type: array
+              defaultCertificate:
+                description: DefaultCertificate defines the default certificate configuration.
+                properties:
+                  secretName:
+                    description: SecretName is the name of the referenced Kubernetes
+                      Secret to specify the certificate details.
+                    type: string
+                required:
+                - secretName
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: traefikservices.traefik.containo.us
+spec:
+  group: traefik.containo.us
+  names:
+    kind: TraefikService
+    listKind: TraefikServiceList
+    plural: traefikservices
+    singular: traefikservice
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'TraefikService is the CRD implementation of a Traefik Service.
+          TraefikService object allows to:  - Apply weight to Services on load-balancing  -
+          Mirror traffic on services More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#kind-traefikservice'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TraefikServiceSpec defines the desired state of a TraefikService.
+            properties:
+              mirroring:
+                description: Mirroring defines the Mirroring service configuration.
+                properties:
+                  kind:
+                    description: Kind defines the kind of the Service.
+                    enum:
+                    - Service
+                    - TraefikService
+                    type: string
+                  maxBodySize:
+                    description: MaxBodySize defines the maximum size allowed for
+                      the body of the request. If the body is larger, the request
+                      is not mirrored. Default value is -1, which means unlimited
+                      size.
+                    format: int64
+                    type: integer
+                  mirrors:
+                    description: Mirrors defines the list of mirrors where Traefik
+                      will duplicate the traffic.
+                    items:
+                      description: MirrorService holds the mirror configuration.
+                      properties:
+                        kind:
+                          description: Kind defines the kind of the Service.
+                          enum:
+                          - Service
+                          - TraefikService
+                          type: string
+                        name:
+                          description: Name defines the name of the referenced Kubernetes
+                            Service or TraefikService. The differentiation between
+                            the two is specified in the Kind field.
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Kubernetes Service or TraefikService.
+                          type: string
+                        passHostHeader:
+                          description: PassHostHeader defines whether the client Host
+                            header is forwarded to the upstream Kubernetes Service.
+                            By default, passHostHeader is true.
+                          type: boolean
+                        percent:
+                          description: 'Percent defines the part of the traffic to
+                            mirror. Supported values: 0 to 100.'
+                          type: integer
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Port defines the port of a Kubernetes Service.
+                            This can be a reference to a named port.
+                          x-kubernetes-int-or-string: true
+                        responseForwarding:
+                          description: ResponseForwarding defines how Traefik forwards
+                            the response from the upstream Kubernetes Service to the
+                            client.
+                          properties:
+                            flushInterval:
+                              description: 'FlushInterval defines the interval, in
+                                milliseconds, in between flushes to the client while
+                                copying the response body. A negative value means
+                                to flush immediately after each write to the client.
+                                This configuration is ignored when ReverseProxy recognizes
+                                a response as a streaming response; for such responses,
+                                writes are flushed to the client immediately. Default:
+                                100ms'
+                              type: string
+                          type: object
+                        scheme:
+                          description: Scheme defines the scheme to use for the request
+                            to the upstream Kubernetes Service. It defaults to https
+                            when Kubernetes Service port is 443, http otherwise.
+                          type: string
+                        serversTransport:
+                          description: ServersTransport defines the name of ServersTransport
+                            resource to use. It allows to configure the transport
+                            between Traefik and your servers. Can only be used on
+                            a Kubernetes Service.
+                          type: string
+                        sticky:
+                          description: 'Sticky defines the sticky sessions configuration.
+                            More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                          properties:
+                            cookie:
+                              description: Cookie defines the sticky cookie configuration.
+                              properties:
+                                httpOnly:
+                                  description: HTTPOnly defines whether the cookie
+                                    can be accessed by client-side APIs, such as JavaScript.
+                                  type: boolean
+                                name:
+                                  description: Name defines the Cookie name.
+                                  type: string
+                                sameSite:
+                                  description: 'SameSite defines the same site policy.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                                  type: string
+                                secure:
+                                  description: Secure defines whether the cookie can
+                                    only be transmitted over an encrypted connection
+                                    (i.e. HTTPS).
+                                  type: boolean
+                              type: object
+                          type: object
+                        strategy:
+                          description: Strategy defines the load balancing strategy
+                            between the servers. RoundRobin is the only supported
+                            value at the moment.
+                          type: string
+                        weight:
+                          description: Weight defines the weight and should only be
+                            specified when Name references a TraefikService object
+                            (and to be precise, one that embeds a Weighted Round Robin).
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  name:
+                    description: Name defines the name of the referenced Kubernetes
+                      Service or TraefikService. The differentiation between the two
+                      is specified in the Kind field.
+                    type: string
+                  namespace:
+                    description: Namespace defines the namespace of the referenced
+                      Kubernetes Service or TraefikService.
+                    type: string
+                  passHostHeader:
+                    description: PassHostHeader defines whether the client Host header
+                      is forwarded to the upstream Kubernetes Service. By default,
+                      passHostHeader is true.
+                    type: boolean
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port defines the port of a Kubernetes Service. This
+                      can be a reference to a named port.
+                    x-kubernetes-int-or-string: true
+                  responseForwarding:
+                    description: ResponseForwarding defines how Traefik forwards the
+                      response from the upstream Kubernetes Service to the client.
+                    properties:
+                      flushInterval:
+                        description: 'FlushInterval defines the interval, in milliseconds,
+                          in between flushes to the client while copying the response
+                          body. A negative value means to flush immediately after
+                          each write to the client. This configuration is ignored
+                          when ReverseProxy recognizes a response as a streaming response;
+                          for such responses, writes are flushed to the client immediately.
+                          Default: 100ms'
+                        type: string
+                    type: object
+                  scheme:
+                    description: Scheme defines the scheme to use for the request
+                      to the upstream Kubernetes Service. It defaults to https when
+                      Kubernetes Service port is 443, http otherwise.
+                    type: string
+                  serversTransport:
+                    description: ServersTransport defines the name of ServersTransport
+                      resource to use. It allows to configure the transport between
+                      Traefik and your servers. Can only be used on a Kubernetes Service.
+                    type: string
+                  sticky:
+                    description: 'Sticky defines the sticky sessions configuration.
+                      More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                    properties:
+                      cookie:
+                        description: Cookie defines the sticky cookie configuration.
+                        properties:
+                          httpOnly:
+                            description: HTTPOnly defines whether the cookie can be
+                              accessed by client-side APIs, such as JavaScript.
+                            type: boolean
+                          name:
+                            description: Name defines the Cookie name.
+                            type: string
+                          sameSite:
+                            description: 'SameSite defines the same site policy. More
+                              info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                            type: string
+                          secure:
+                            description: Secure defines whether the cookie can only
+                              be transmitted over an encrypted connection (i.e. HTTPS).
+                            type: boolean
+                        type: object
+                    type: object
+                  strategy:
+                    description: Strategy defines the load balancing strategy between
+                      the servers. RoundRobin is the only supported value at the moment.
+                    type: string
+                  weight:
+                    description: Weight defines the weight and should only be specified
+                      when Name references a TraefikService object (and to be precise,
+                      one that embeds a Weighted Round Robin).
+                    type: integer
+                required:
+                - name
+                type: object
+              weighted:
+                description: Weighted defines the Weighted Round Robin configuration.
+                properties:
+                  services:
+                    description: Services defines the list of Kubernetes Service and/or
+                      TraefikService to load-balance, with weight.
+                    items:
+                      description: Service defines an upstream HTTP service to proxy
+                        traffic to.
+                      properties:
+                        kind:
+                          description: Kind defines the kind of the Service.
+                          enum:
+                          - Service
+                          - TraefikService
+                          type: string
+                        name:
+                          description: Name defines the name of the referenced Kubernetes
+                            Service or TraefikService. The differentiation between
+                            the two is specified in the Kind field.
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Kubernetes Service or TraefikService.
+                          type: string
+                        passHostHeader:
+                          description: PassHostHeader defines whether the client Host
+                            header is forwarded to the upstream Kubernetes Service.
+                            By default, passHostHeader is true.
+                          type: boolean
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Port defines the port of a Kubernetes Service.
+                            This can be a reference to a named port.
+                          x-kubernetes-int-or-string: true
+                        responseForwarding:
+                          description: ResponseForwarding defines how Traefik forwards
+                            the response from the upstream Kubernetes Service to the
+                            client.
+                          properties:
+                            flushInterval:
+                              description: 'FlushInterval defines the interval, in
+                                milliseconds, in between flushes to the client while
+                                copying the response body. A negative value means
+                                to flush immediately after each write to the client.
+                                This configuration is ignored when ReverseProxy recognizes
+                                a response as a streaming response; for such responses,
+                                writes are flushed to the client immediately. Default:
+                                100ms'
+                              type: string
+                          type: object
+                        scheme:
+                          description: Scheme defines the scheme to use for the request
+                            to the upstream Kubernetes Service. It defaults to https
+                            when Kubernetes Service port is 443, http otherwise.
+                          type: string
+                        serversTransport:
+                          description: ServersTransport defines the name of ServersTransport
+                            resource to use. It allows to configure the transport
+                            between Traefik and your servers. Can only be used on
+                            a Kubernetes Service.
+                          type: string
+                        sticky:
+                          description: 'Sticky defines the sticky sessions configuration.
+                            More info: https://doc.traefik.io/traefik/v2.8/routing/services/#sticky-sessions'
+                          properties:
+                            cookie:
+                              description: Cookie defines the sticky cookie configuration.
+                              properties:
+                                httpOnly:
+                                  description: HTTPOnly defines whether the cookie
+                                    can be accessed by client-side APIs, such as JavaScript.
+                                  type: boolean
+                                name:
+                                  description: Name defines the Cookie name.
+                                  type: string
+                                sameSite:
+                                  description: 'SameSite defines the same site policy.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                                  type: string
+                                secure:
+                                  description: Secure defines whether the cookie can
+                                    only be transmitted over an encrypted connection
+                                    (i.e. HTTPS).
+                                  type: boolean
+                              type: object
+                          type: object
+                        strategy:
+                          description: Strategy defines the load balancing strategy
+                            between the servers. RoundRobin is the only supported
+                            value at the moment.
+                          type: string
+                        weight:
+                          description: Weight defines the weight and should only be
+                            specified when Name references a TraefikService object
+                            (and to be precise, one that embeds a Weighted Round Robin).
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  sticky:
+                    description: 'Sticky defines whether sticky sessions are enabled.
+                      More info: https://doc.traefik.io/traefik/v2.8/routing/providers/kubernetes-crd/#stickiness-and-load-balancing'
+                    properties:
+                      cookie:
+                        description: Cookie defines the sticky cookie configuration.
+                        properties:
+                          httpOnly:
+                            description: HTTPOnly defines whether the cookie can be
+                              accessed by client-side APIs, such as JavaScript.
+                            type: boolean
+                          name:
+                            description: Name defines the Cookie name.
+                            type: string
+                          sameSite:
+                            description: 'SameSite defines the same site policy. More
+                              info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite'
+                            type: string
+                          secure:
+                            description: Secure defines whether the cookie can only
+                              be transmitted over an encrypted connection (i.e. HTTPS).
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes-config/files/traefik.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes-config/files/traefik.yml
@@ -1,0 +1,133 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traefik
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traefik-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - traefik.containo.us
+    resources:
+      - middlewares
+      - middlewaretcps
+      - ingressroutes
+      - traefikservices
+      - ingressroutetcps
+      - ingressrouteudps
+      - tlsoptions
+      - tlsstores
+      - serverstransports
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: traefik
+  name: traefik-ingress-controller
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traefik-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: traefik-ingress-controller
+    namespace: traefik
+
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  namespace: traefik
+  name: traefik
+  labels:
+    app: traefik
+spec:
+  selector:
+    matchLabels:
+      app: traefik
+  template:
+    metadata:
+      labels:
+        app: traefik
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: traefik-ingress-controller
+      containers:
+        - name: traefik
+          image: traefik:v2.8.1
+          args:
+            - --entrypoints.web.Address=:80
+            - --entrypoints.web.proxyProtocol.insecure
+            - --entrypoints.web.forwardedHeaders.insecure
+            - --providers.kubernetescrd
+            - --api.insecure
+            - --api.dashboard
+          ports:
+            - name: web
+              containerPort: 80
+            - name: admin
+              containerPort: 8080
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: traefik
+  name: traefik
+  labels:
+    name: traefik
+spec:
+  externalTrafficPolicy: Local
+  type: NodePort
+  ports:
+    - port: 80
+      nodePort: 80
+      name: web
+    - port: 8080
+      nodePort: 8080
+      name: admin
+  selector:
+    app: traefik

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes-config/files/whoami.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes-config/files/whoami.yml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: whoami
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whoami
+  namespace: whoami
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: whoami
+  template:
+    metadata:
+      labels:
+        app: whoami
+    spec:
+      containers:
+      - name: whoami-container
+        image: traefik/whoami:v1.8.1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-service
+  namespace: whoami
+spec:
+  ports:
+  - name: http
+    targetPort: 80
+    port: 80
+  selector:
+    app: whoami
+
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: whoami
+  namespace: whoami
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Path(`/`)
+      kind: Rule
+      services:
+        - name: whoami-service
+          port: 80
+          namespace: whoami

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes-config/tasks/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes-config/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Create the custom resource definitions
+  k8s:
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
+    resource_definition: "{{ lookup('file', 'crds.yml') }}"
+    state: present
+  run_once: true
+
+- name: Create the ingress controller
+  k8s:
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
+    resource_definition: "{{ lookup('file', 'traefik.yml') }}"
+    state: present
+  run_once: true
+
+- name: Create the app
+  k8s:
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
+    resource_definition: "{{ lookup('file', 'whoami.yml') }}"
+    state: present
+  run_once: true

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/defaults/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/defaults/main.yml
@@ -1,0 +1,3 @@
+k3s_version: "v1.21.5+k3s1"
+python_kubernetes_version: "11.0.0"
+python_openshift_version: "0.11.2"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/handlers/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/handlers/main.yml
@@ -1,0 +1,11 @@
+- name: Restart k3s-server
+  systemd:
+    name: k3s-server
+    state: restarted
+    daemon_reload: yes
+
+- name: Restart k3s-agent
+  systemd:
+    name: k3s-agent
+    state: restarted
+    daemon_reload: yes

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/install.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/install.yml
@@ -1,0 +1,14 @@
+- name: Download k3s
+  get_url:
+    url: "https://github.com/rancher/k3s/releases/download/{{k3s_version}}/k3s"
+    dest: /usr/local/bin/k3s
+    mode: '0755'
+
+- name: Install systemd unit file
+  template:
+    src: k3s.service.j2
+    dest: "/etc/systemd/system/k3s-{{role}}.service"
+    owner: root
+    group: root
+    mode: '0644'
+  notify: "Restart k3s-{{role}}"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/install_ansible_requirements.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/install_ansible_requirements.yml
@@ -1,0 +1,12 @@
+- name: Install python setuptools and pip
+  apt:
+    name:
+      - python3-setuptools
+      - python3-pip
+
+- name: Install python packages for ansible management
+  pip:
+    name: "{{item}}"
+  loop:
+    - "kubernetes=={{python_kubernetes_version}}"
+    - "openshift=={{python_openshift_version}}"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/main.yml
@@ -1,0 +1,7 @@
+- include_tasks: install.yml
+- include_tasks: install_ansible_requirements.yml
+  when: role == "server"
+- meta: flush_handlers
+- include_tasks: token.yml
+  when: role == "server"
+- include_tasks: service.yml

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/service.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/service.yml
@@ -1,0 +1,5 @@
+- name: Start k3s
+  systemd:
+    name: "k3s-{{role}}"
+    state: started
+    enabled: yes

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/token.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/tasks/token.yml
@@ -1,0 +1,12 @@
+- name: Wait until the cluster boostrap is ok
+  wait_for:
+    path:  /var/lib/rancher/k3s/server/node-token
+    timeout: 30
+
+- name: Get server token
+  shell: cat /var/lib/rancher/k3s/server/node-token
+  changed_when: false
+  register: tokencmd
+
+- set_fact:
+    token: "{{tokencmd.stdout}}"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/templates/k3s.service.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/kubernetes/templates/k3s.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=Lightweight Kubernetes
+Documentation=https://k3s.io
+Wants=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type={{role}}
+KillMode=process
+Delegate=yes
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Restart=always
+RestartSec=5s
+ExecStartPre=-/sbin/modprobe br_netfilter
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/k3s {% if role == 'server' %}server --no-deploy traefik --kube-apiserver-arg service-node-port-range=1-65535 --flannel-backend=host-gw{% else %}agent --server https://{{ (groups['kubernetes'] | map('extract', hostvars)  | selectattr('role', 'equalto', 'server') | map(attribute="ansible_default_ipv4.address") | list)[0] }}:6443 --token {{ (groups['kubernetes'] | map('extract', hostvars)  | selectattr('role', 'equalto', 'server') | map(attribute="token") | list)[0] }}{% endif %}

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefik/defaults/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefik/defaults/main.yml
@@ -1,0 +1,2 @@
+traefik_version: "2.8.1"
+backends: ""

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefik/handlers/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefik/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart traefik
+  systemd:
+    name: traefik
+    state: restarted

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefik/tasks/config.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefik/tasks/config.yml
@@ -1,0 +1,11 @@
+- name: Configure traefik
+  template:
+    src: "{{item}}.j2"
+    dest: "/etc/traefik/{{item}}"
+    owner: root
+    group: root
+    mode: '0644'
+  with_items:
+    - traefik.toml
+    - dynamic_conf.toml
+  notify: Restart traefik

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefik/tasks/install.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefik/tasks/install.yml
@@ -1,0 +1,49 @@
+- name: Download and install traefik
+  unarchive:
+    src: https://github.com/traefik/traefik/releases/download/v{{traefik_version}}/traefik_v{{traefik_version}}_linux_amd64.tar.gz
+    dest: /usr/local/bin
+    remote_src: yes
+    exclude:
+      - "*.md"
+  args:
+    creates: /usr/local/bin/traefik
+
+- name: Create traefik user
+  user:
+    name: traefik
+    comment: trafik user
+    system: yes
+    home: /var/www
+    shell: /usr/sbin/nologin
+
+- name: Set user caps
+  capabilities:
+    path:  /usr/local/bin/traefik
+    capability: cap_net_bind_service=+ep
+    state: present
+  changed_when: false
+
+- name: Create config dir
+  file:
+    path: /etc/traefik
+    owner: root
+    group: root
+    mode: '0755'
+    state: directory
+
+- name: Create acme dir
+  file:
+    path: /etc/traefik/acme
+    owner: traefik
+    group: traefik
+    mode: '0700'
+    state: directory
+
+- name: Install systemd unit file
+  template:
+    src: traefik.service.j2
+    dest: /etc/systemd/system/traefik.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart traefik

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefik/tasks/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefik/tasks/main.yml
@@ -1,0 +1,3 @@
+- include_tasks: install.yml
+- include_tasks: config.yml
+- include_tasks: service.yml

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefik/tasks/service.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefik/tasks/service.yml
@@ -1,0 +1,6 @@
+- name: Run traefik
+  systemd:
+    state: started
+    name: traefik
+    daemon_reload: yes
+    enabled: yes

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefik/templates/dynamic_conf.toml.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefik/templates/dynamic_conf.toml.j2
@@ -1,0 +1,17 @@
+[http.routers]
+    [http.routers.router]
+        rule = "Path(`/`)"
+        service = "service"
+        middlewares = ["LBHeader"]
+
+[http.services]
+    [http.services.service.loadBalancer]
+{% for backend in backends.split(',') %}
+        [[http.services.service.loadBalancer.servers]]
+            url = "{{backend}}"
+{% endfor %}
+
+[http.middlewares]
+  [http.middlewares.LBHeader.headers]
+    [http.middlewares.LBHeader.headers.customResponseHeaders]
+        X-Lb-Name = "{{ansible_hostname}}"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefik/templates/traefik.service.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefik/templates/traefik.service.j2
@@ -1,0 +1,39 @@
+[Unit]
+Description=traefik proxy
+After=network-online.target
+Wants=network-online.target systemd-networkd-wait-online.service
+
+[Service]
+Restart=on-abnormal
+
+; User and group the process will run as.
+User=traefik
+Group=traefik
+
+; Always set "-root" to something safe in case it gets forgotten in the traefikfile.
+ExecStart=/usr/local/bin/traefik --configfile=/etc/traefik/traefik.toml
+
+; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
+LimitNOFILE=1048576
+
+; Use private /tmp and /var/tmp, which are discarded after traefik stops.
+PrivateTmp=true
+; Use a minimal /dev (May bring additional security if switched to 'true', but it may not work on Raspberry Pi's or other devices, so it has been disabled in this dist.)
+PrivateDevices=false
+; Hide /home, /root, and /run/user. Nobody will steal your SSH-keys.
+ProtectHome=true
+; Make /usr, /boot, /etc and possibly some more folders read-only.
+ProtectSystem=full
+; … except /etc/ssl/traefik, because we want Letsencrypt-certificates there.
+;   This merely retains r/w access rights, it does not add any new. Must still be writable on the host!
+ReadWriteDirectories=/etc/traefik/acme
+
+; The following additional security directives only work with systemd v229 or later.
+; They further restrict privileges that can be gained by traefik. Uncomment if you like.
+; Note that you may have to add capabilities required by any plugins in use.
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefik/templates/traefik.toml.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefik/templates/traefik.toml.j2
@@ -1,0 +1,16 @@
+[log]
+  level = "DEBUG"
+  filePath = "/tmp/traefik.log"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":80"
+
+[api]
+  insecure = true
+  dashboard = true
+
+[providers]
+  [providers.file]
+    filename = "/etc/traefik/dynamic_conf.toml"
+    watch = true

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/defaults/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/defaults/main.yml
@@ -1,0 +1,4 @@
+traefikee_version: "2.7.0"
+traefikee_license_key: "N/A"
+traefikee_controller_port: 4242
+backends: ""

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/handlers/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/handlers/main.yml
@@ -1,0 +1,13 @@
+- name: Restart traefikee
+  systemd:
+    name: "traefikee-{{traefikee_role}}"
+    state: restarted
+    daemon_reload: yes
+
+- name: Apply config
+  shell:
+    cmd: "{{item}}"
+  run_once: true
+  with_items:
+      - "teectl apply --socket=/var/run/traefikee/teectl.sock --file=/etc/traefikee/traefik.toml"
+      - "teectl apply --socket=/var/run/traefikee/teectl.sock --file=/etc/traefikee/dynamic_conf.toml"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/config.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/config.yml
@@ -1,0 +1,11 @@
+- name: Configure traefik
+  template:
+    src: "{{item}}.j2"
+    dest: "/etc/traefikee/{{item}}"
+    owner: root
+    group: root
+    mode: '0644'
+  with_items:
+    - traefik.toml
+    - dynamic_conf.toml
+  notify: Apply config

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/install.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/install.yml
@@ -1,0 +1,51 @@
+- name: Download and install traefikee
+  unarchive:
+    src: https://s3.amazonaws.com/traefikee/binaries/v{{traefikee_version}}/traefikee_v{{traefikee_version}}_linux_amd64.tar.gz
+    dest: /usr/local/bin
+    remote_src: yes
+    exclude:
+      - "docs"
+  args:
+    creates: /usr/local/bin/traefikee
+
+- name: Download and install teectl
+  unarchive:
+    src: https://s3.amazonaws.com/traefikee/binaries/v{{traefikee_version}}/teectl_v{{traefikee_version}}_linux_amd64.tar.gz
+    dest: /usr/local/bin
+    remote_src: yes
+    exclude:
+      - "docs"
+  args:
+    creates: /usr/local/bin/teectl
+
+- name: Create traefikee user
+  user:
+    name: traefikee
+    comment: trafikee user
+    system: yes
+    home: /var/lib/traefikee
+    create_home: yes
+    shell: /usr/sbin/nologin
+
+# - name: Set user caps
+#   capabilities:
+#     path:  /usr/local/bin/traefik
+#     capability: cap_net_bind_service=+ep
+#     state: present
+#   changed_when: false
+
+# - name: Create config dir
+#   file:
+#     path: /etc/traefik
+#     owner: root
+#     group: root
+#     mode: '0755'
+#     state: directory
+
+# - name: Create acme dir
+#   file:
+#     path: /etc/traefik/acme
+#     owner: traefik
+#     group: traefik
+#     mode: '0700'
+#     state: directory

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/install_controller.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/install_controller.yml
@@ -1,0 +1,25 @@
+- name: Install environment file
+  template:
+    src: traefikee-controller.j2
+    dest: /etc/default/traefikee-controller
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart traefikee
+
+- name: Install systemd unit file
+  template:
+    src: traefikee-controller.service.j2
+    dest: /etc/systemd/system/traefikee-controller.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart traefikee
+
+- name: Create config dir
+  file:
+    path: /etc/traefikee
+    owner: root
+    group: root
+    mode: '0755'
+    state: directory

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/install_proxy.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/install_proxy.yml
@@ -1,0 +1,17 @@
+- name: Install environment file
+  template:
+    src: traefikee-proxy.j2
+    dest: /etc/default/traefikee-proxy
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart traefikee
+
+- name: Install systemd unit file
+  template:
+    src: traefikee-proxy.service.j2
+    dest: /etc/systemd/system/traefikee-proxy.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart traefikee

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/main.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/main.yml
@@ -1,0 +1,22 @@
+- fail:
+    msg: "No license key provided, please ask for a trial !"
+  when: traefikee_license_key == 'N/A'
+
+- include_tasks: install.yml
+- include_tasks: "install_{{traefikee_role}}.yml"
+  when: traefikee_role == 'controller'
+- meta: flush_handlers
+- include_tasks: token.yml
+  when: traefikee_role == 'controller'
+
+- include_tasks: "install_{{traefikee_role}}.yml"
+  when: traefikee_role == 'proxy'
+
+- include_tasks: ssl.yml
+  when: traefikee_role == 'controller'
+
+- include_tasks: config.yml
+  when: traefikee_role == 'controller'
+  run_once: true
+
+- include_tasks: service.yml

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/service.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/service.yml
@@ -1,0 +1,6 @@
+- name: Run traefikee
+  systemd:
+    state: started
+    name: "traefikee-{{traefikee_role}}"
+    daemon_reload: yes
+    enabled: yes

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/ssl.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/ssl.yml
@@ -1,0 +1,55 @@
+- name: Install cfssl
+  apt:
+    name:
+      - golang-cfssl
+    state: present
+
+- name: Create ssl dir
+  file:
+    path: /etc/ssl/traefikee/
+    owner: root
+    group: root
+    mode: '0755'
+    state: directory
+
+- name: Copy ssl stuff
+  template:
+    src: "{{item}}.j2"
+    dest: "/etc/ssl/traefikee/{{item}}"
+    owner: root
+    group: root
+    mode: '0644'
+  with_items:
+    - ca-config.json
+    - ca-csr.json
+    - loadbalancer-csr.json
+
+- name: Create the CA
+  shell:
+    cmd: "cfssl gencert -initca ca-csr.json | cfssljson -bare ca"
+    chdir: /etc/ssl/traefikee/
+  args:
+    creates: /etc/ssl/traefikee/ca.pem
+
+- name: Create the cert
+  shell:
+    cmd: "cfssl gencert -ca=ca.pem  -ca-key=ca-key.pem -config=ca-config.json -profile=server loadbalancer-csr.json | cfssljson -bare loadbalancer"
+    chdir: /etc/ssl/traefikee/
+  args:
+    creates: /etc/ssl/traefikee/loadbalancer.pem
+  register: ssl
+
+- name: Install the SSL cert in traefikee
+  shell:
+    cmd: "{{item}}"
+  when: ssl.changed
+  with_items:
+    - (teectl delete tls-cert --id $(teectl get tls-certs | grep loadbalancer | awk '{ print $1 }')) || echo "not existing"
+    - teectl create tls-cert --cert=/etc/ssl/traefikee/loadbalancer.pem --key=/etc/ssl/traefikee/loadbalancer-key.pem
+
+- name: Get CA public key
+  fetch:
+    src: /etc/ssl/traefikee/ca.pem
+    dest: "/tmp/traefikee_{{ansible_hostname}}.pem"
+    flat: yes
+  changed_when: false

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/token.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/tasks/token.yml
@@ -1,0 +1,12 @@
+- name: Wait until the cluster boostrap is ok
+  wait_for:
+    path:  /var/lib/traefikee/tokens/proxy
+    timeout: 30
+
+- name: Get proxy token
+  shell: cat /var/lib/traefikee/tokens/proxy
+  changed_when: false
+  register: tokencmd
+
+- set_fact:
+    token: "{{tokencmd.stdout}}"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/ca-config.json.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/ca-config.json.j2
@@ -1,0 +1,17 @@
+{
+  "signing": {
+    "default": {
+      "expiry": "8760h"
+    },
+    "profiles": {
+      "server": {
+        "expiry": "43800h",
+        "usages": [
+          "signing",
+          "key encipherment",
+          "server auth"
+        ]
+      }
+    }
+  }
+}

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/ca-csr.json.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/ca-csr.json.j2
@@ -1,0 +1,15 @@
+{
+  "CN": "TraefikEE CA",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "FR",
+      "L": "EARTH",
+      "emailAddress": "noreply@traefik.io",
+      "OU": "Traefik Labs"
+    }
+  ]
+}

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/dynamic_conf.toml.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/dynamic_conf.toml.j2
@@ -1,0 +1,27 @@
+[http.routers]
+   [http.routers.router]
+        rule = "Path(`/`)"
+        service = "service"
+        middlewares = ["LBratelimit"]
+    [http.routers.routerTLS]
+        rule = "Path(`/`)"
+        service = "service"
+        middlewares = ["LBratelimit"]
+    [http.routers.routerTLS.tls]
+
+[http.services]
+    [http.services.service.loadBalancer]
+        [http.services.service.loadBalancer.healthCheck]
+            path = "/"
+            interval = "10s"
+            timeout = "3s"
+
+{% for backend in backends.split(',') %}
+        [[http.services.service.loadBalancer.servers]]
+            url = "{{backend}}"
+{% endfor %}
+
+[http.middlewares]
+    [http.middlewares.LBratelimit.plugin.rateLimit]
+        average = 10
+        burst = 10

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/loadbalancer-csr.json.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/loadbalancer-csr.json.j2
@@ -1,0 +1,19 @@
+{
+  "CN": "loadbalancer",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "FR",
+      "L": "EARTH",
+      "emailAddress": "noreply@traefik.io",
+      "OU": "Traefik Labs"
+    }
+  ],
+  "hosts": [
+     "loadbalancer",
+     "{{vip}}"
+  ]
+}

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefik.toml.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefik.toml.j2
@@ -1,0 +1,21 @@
+[log]
+  level = "INFO"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":80"
+    [entryPoints.web.proxyProtocol]
+      insecure = true
+    [entryPoints.web.forwardedHeaders]
+      insecure = true
+
+  [entryPoints.websecure]
+    address = ":443"
+    [entryPoints.websecure.proxyProtocol]
+      insecure = true
+    [entryPoints.websecure.forwardedHeaders]
+      insecure = true
+
+[api]
+  insecure = true
+  dashboard = true

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefikee-controller.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefikee-controller.j2
@@ -1,0 +1,2 @@
+CONTROLLER_BIND_ADDRESS="{{ansible_default_ipv4['address']}}:{{traefikee_controller_port}}"
+TEE_LICENSE_KEY="{{traefikee_license_key}}"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefikee-controller.service.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefikee-controller.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=Traefik Enterprise Controller
+After=network-online.target
+Wants=network-online.target systemd-networkd-wait-online.service
+
+[Service]
+EnvironmentFile=-/etc/default/traefikee-controller
+Restart=on-abnormal
+User=traefikee
+Group=traefikee
+ExecStart=/usr/local/bin/traefikee controller --advertise=${CONTROLLER_BIND_ADDRESS} --license=${TEE_LICENSE_KEY} --api.socket=/var/run/traefikee/teectl.sock --socket=/var/run/traefikee/cluster.sock --statedir=/var/lib/traefikee/data --jointoken.file.path=/var/lib/traefikee/tokens
+PrivateTmp=true
+PrivateDevices=false
+ProtectHome=true
+ProtectSystem=full
+ReadWritePaths=/var/lib/traefikee
+PermissionsStartOnly=true
+NoNewPrivileges=true
+RuntimeDirectory=traefikee
+
+[Install]
+WantedBy=multi-user.target

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefikee-proxy.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefikee-proxy.j2
@@ -1,0 +1,3 @@
+CONTROLLER_PEERS="{{ groups['traefikee'] | map('extract', hostvars)  | selectattr('traefikee_role', 'equalto', 'controller') | map(attribute="ansible_default_ipv4.address") | map('regex_replace', '^(.*)$', '\\1:'+traefikee_controller_port|string) | join(',') }}"
+PROXY_NODE_TOKEN="{{ (groups['traefikee'] | map('extract', hostvars)  | selectattr('traefikee_role', 'equalto', 'controller') | map(attribute="token") | list)[0] }}"
+HOSTNAME="{{ansible_hostname}}"

--- a/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefikee-proxy.service.j2
+++ b/2022_07_15-traefik-load-balancing/ansible/roles/traefikee/templates/traefikee-proxy.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=Traefik Enterprise proxy
+After=network-online.target
+Wants=network-online.target systemd-networkd-wait-online.service
+
+[Service]
+EnvironmentFile=-/etc/default/traefikee-proxy
+Restart=on-abnormal
+User=traefikee
+Group=traefikee
+ExecStart=/usr/local/bin/traefikee proxy --jointoken.value=${PROXY_NODE_TOKEN} --discovery.static.peers=${CONTROLLER_PEERS} --statedir=/var/lib/traefikee/data
+PrivateTmp=true
+PrivateDevices=false
+ProtectHome=true
+ProtectSystem=full
+ReadWritePaths=/var/lib/traefikee
+
+; The following additional security directives only work with systemd v229 or later.
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/2022_07_15-traefik-load-balancing/ansible/site.yml
+++ b/2022_07_15-traefik-load-balancing/ansible/site.yml
@@ -1,0 +1,72 @@
+- hosts: all
+  roles:
+    - role: base
+  tags:
+    - base
+
+- hosts: traefik
+  roles:
+    - role: traefik
+  tags:
+    - traefik
+
+- hosts: fakeservice
+  roles:
+    - role: fake-service
+  tags:
+    - fake-service
+
+- hosts: traefikee
+  roles:
+    - role: traefikee
+      when: traefikee_role == "controller"
+  tags:
+    - traefikee
+
+- hosts: traefikee
+  roles:
+    - role: traefikee
+      when: traefikee_role == "proxy"
+  tags:
+    - traefikee
+
+- hosts: keepalived
+  roles:
+    - role: keepalived
+  tags:
+    - keepalived
+
+- hosts: kubernetes
+  roles:
+    - role: kubernetes
+      when: role == "server"
+  tags:
+    - kubernetes
+
+- hosts: kubernetes
+  roles:
+    - role: kubernetes
+      when: role == "agent"
+  tags:
+    - kubernetes
+
+- hosts: kubernetes
+  roles:
+    - role: kubernetes-config
+      when: role == "server"
+  tags:
+    - kubernetes-config
+
+- hosts: bird
+  roles:
+    - role: bird
+      when: role == "router"
+  tags:
+    - bird
+
+- hosts: bird
+  roles:
+    - role: bird
+      when: role != "router"
+  tags:
+    - bird

--- a/2022_07_15-traefik-load-balancing/packer/base.json
+++ b/2022_07_15-traefik-load-balancing/packer/base.json
@@ -1,0 +1,53 @@
+{
+  "variables": {
+    "login": "root",
+    "password": "{{env `ROOT_PASSWORD`}}",
+    "sshkey": "{{env `SSH_PUB_KEY`}}"
+  },
+  "builders": [
+    {
+      "accelerator": "kvm",
+      "boot_command": [
+        "<down><down><enter><down><down><down><down><down><down><tab>",
+        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian11.txt.password ",
+        "auto-install/enable=true ",
+        "DEBCONF_DEBUG=5",
+        "<enter>"
+      ],
+      "boot_wait": "2s",
+      "boot_key_interval": "10ms",
+      "disk_interface": "virtio",
+      "disk_size": "30720M",
+      "format": "qcow2",
+      "http_directory": "./preseed/",
+      "iso_checksum": "file:https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS",
+      "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-11.4.0-amd64-netinst.iso",
+      "memory": 1024,
+      "net_device": "virtio-net",
+      "output_directory": "output",
+      "qemuargs": [
+        ["-display", "none"],
+        ["-cpu", "host"]
+      ],
+      "shutdown_command": "shutdown -P now",
+      "ssh_password": "{{ user `password` }}",
+      "ssh_timeout": "20m",
+      "ssh_username": "{{ user `login` }}",
+      "type": "qemu",
+      "vm_name": "debian11"
+    }
+  ],
+  "provisioners": [
+    {
+      "inline": [
+        "mkdir /root/.ssh",
+        "echo \"{{ user `sshkey` }}\" > /root/.ssh/authorized_keys",
+        "sed -e '/^PasswordAuthentication yes/d' -e '/^PermitRootLogin yes/d' -i /etc/ssh/sshd_config",
+        "echo 'WantedBy=dev-virtio\\x2dports-org.qemu.guest_agent.0.device' >> /lib/systemd/system/qemu-guest-agent.service",
+        "systemctl daemon-reload",
+        "systemctl enable qemu-guest-agent.service"
+      ],
+      "type": "shell"
+    }
+  ]
+}

--- a/2022_07_15-traefik-load-balancing/packer/preseed/debian11.txt
+++ b/2022_07_15-traefik-load-balancing/packer/preseed/debian11.txt
@@ -1,0 +1,74 @@
+#### Contents of the preconfiguration file (for buster)
+### Localization
+# Preseeding only locale sets language, country and locale.
+d-i debian-installer/locale string fr_FR
+d-i debian-installer/locale string fr_FR.UTF-8
+
+# Keyboard selection.
+d-i keyboard-configuration/xkb-keymap select fr
+
+### Network configuration
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string debian11
+d-i netcfg/get_domain string traefik.local
+
+### Mirror settings
+d-i mirror/country string manual
+d-i mirror/http/hostname string httpredir.debian.org
+d-i mirror/http/directory string /debian
+d-i mirror/http/proxy string
+
+### Account setup
+d-i passwd/root-login boolean true
+d-i passwd/make-user boolean false
+d-i passwd/root-password-crypted password
+d-i clock-setup/utc boolean true
+d-i time/zone string Europe/Paris
+d-i clock-setup/ntp boolean true
+
+### Partitioning
+
+#d-i partman-auto/disk string /dev/vda
+# On partionne en "normal": pas de RAID ni de LVM
+d-i partman-auto/method string regular
+# Pour être sûr, on supprime une éventuelle configuration LVM
+d-i partman-lvm/device_remove_lvm boolean true
+# Même chose pour le RAID
+d-i partman-md/device_remove_md boolean true
+# Chaînes pour ne pas toucher la configuration LVM (donc pas de configuration)
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+# L'installation sera simple: on fout tout dans une seule partition
+d-i partman-auto/choose_recipe select atomic
+
+# On valide sans confirmation la configuration de partman
+d-i partman-md/confirm boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+### Package selection
+
+# Individual additional packages to install
+tasksel tasksel/first multiselect standard
+d-i pkgsel/include string openssh-server qemu-guest-agent build-essential
+
+### Boot loader installation
+d-i grub-installer/choose_bootdev select /dev/vda
+
+# This is fairly safe to set, it makes grub install automatically to the MBR
+# if no other operating system is detected on the machine.
+d-i grub-installer/only_debian boolean true
+
+# This one makes grub-installer install to the MBR if it also finds some other
+# OS, which is less safe as it might not be able to boot that other OS.
+#d-i grub-installer/with_other_os boolean true
+
+# Avoid that last message about the install being complete.
+d-i finish-install/reboot_in_progress note
+
+#### Advanced options
+### Running custom commands during the installation
+d-i preseed/late_command string echo -e "PasswordAuthentication yes\nPermitRootLogin yes\n" >> /target/etc/ssh/sshd_config

--- a/2022_07_15-traefik-load-balancing/terraform/cluster1.tfvars
+++ b/2022_07_15-traefik-load-balancing/terraform/cluster1.tfvars
@@ -1,0 +1,33 @@
+vms = [
+  {
+    name   = "traefik-lb1"
+    cpu    = 1
+    memory = 512
+    ip     = 61
+    groups = ["keepalived", "traefik", "fakeservice", "cluster1"]
+    vars = {
+      role = "master"
+    }
+  },
+  {
+    name   = "traefik-lb2"
+    cpu    = 1
+    memory = 512
+    ip     = 62
+    groups = ["keepalived", "traefik", "fakeservice", "cluster1"]
+    vars = {
+      role = "backup"
+    }
+  }
+]
+cluster = 1
+vip     = 60
+backends = [
+  {
+    ip   = "127.0.0.1"
+    port = 8888
+  }
+]
+keepalived_pass      = "tr@3fiK1"
+keepalived_router_id = 42
+keepalived_check     = "check_traefik"

--- a/2022_07_15-traefik-load-balancing/terraform/cluster2.tfvars
+++ b/2022_07_15-traefik-load-balancing/terraform/cluster2.tfvars
@@ -1,0 +1,79 @@
+vms = [
+  {
+    name   = "traefik-ctrl1"
+    cpu    = 1
+    memory = 512
+    ip     = 71
+    groups = ["traefikee", "cluster2"]
+    vars = {
+      traefikee_role = "controller"
+    }
+  },
+  {
+    name   = "traefik-lb3"
+    cpu    = 1
+    memory = 512
+    ip     = 72
+    groups = ["keepalived", "traefikee", "cluster2"]
+    vars = {
+      role           = "master"
+      traefikee_role = "proxy"
+    }
+  },
+  {
+    name   = "traefik-lb4"
+    cpu    = 1
+    memory = 512
+    ip     = 73
+    groups = ["keepalived", "traefikee", "cluster2"]
+    vars = {
+      role           = "backup"
+      traefikee_role = "proxy"
+    }
+  },
+  {
+    name   = "kube-node1"
+    cpu    = 1
+    memory = 1024
+    ip     = 74
+    groups = ["kubernetes"]
+    vars = {
+      role = "server"
+    }
+  },
+  {
+    name   = "kube-node2"
+    cpu    = 1
+    memory = 1024
+    ip     = 75
+    groups = ["kubernetes"]
+    vars = {
+      role = "agent"
+    }
+  },
+  {
+    name   = "kube-node3"
+    cpu    = 1
+    memory = 1024
+    ip     = 76
+    groups = ["kubernetes"]
+    vars = {
+      role = "agent"
+    }
+  }
+]
+cluster = 2
+vip     = 70
+backends = [
+  {
+    ip   = "75"
+    port = 80
+  },
+  {
+    ip   = "76"
+    port = 80
+  }
+]
+keepalived_pass      = "tr@3fiK2"
+keepalived_router_id = 43
+keepalived_check     = "check_traefik"

--- a/2022_07_15-traefik-load-balancing/terraform/cluster3.tfvars
+++ b/2022_07_15-traefik-load-balancing/terraform/cluster3.tfvars
@@ -1,0 +1,86 @@
+vms = [
+  {
+    name   = "router-1"
+    cpu    = 1
+    memory = 512
+    ip     = 81
+    groups = ["bird", "cluster3"]
+    vars = {
+      role = "router"
+    }
+  },
+  {
+    name   = "traefik-ctrl2"
+    cpu    = 1
+    memory = 512
+    ip     = 82
+    groups = ["traefikee", "cluster3"]
+    vars = {
+      traefikee_role = "controller"
+    }
+  },
+  {
+    name   = "traefik-lb5"
+    cpu    = 1
+    memory = 512
+    ip     = 83
+    groups = ["bird", "traefikee", "cluster3"]
+    vars = {
+      role           = "client"
+      traefikee_role = "proxy"
+    }
+  },
+  {
+    name   = "traefik-lb6"
+    cpu    = 1
+    memory = 512
+    ip     = 84
+    groups = ["bird", "traefikee", "cluster3"]
+    vars = {
+      role           = "client"
+      traefikee_role = "proxy"
+    }
+  },
+  {
+    name   = "kube-node1"
+    cpu    = 1
+    memory = 1024
+    ip     = 73
+    groups = ["kubernetes"]
+    vars = {
+      role = "server"
+    }
+  },
+  {
+    name   = "kube-node2"
+    cpu    = 1
+    memory = 1024
+    ip     = 74
+    groups = ["kubernetes"]
+    vars = {
+      role = "agent"
+    }
+  },
+  {
+    name   = "kube-node3"
+    cpu    = 1
+    memory = 1024
+    ip     = 75
+    groups = ["kubernetes"]
+    vars = {
+      role = "agent"
+    }
+  }
+]
+cluster = 3
+vip     = 80
+backends = [
+  {
+    ip   = "75"
+    port = 80
+  },
+  {
+    ip   = "76"
+    port = 80
+  }
+]

--- a/2022_07_15-traefik-load-balancing/terraform/provider.tf
+++ b/2022_07_15-traefik-load-balancing/terraform/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.14"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "libvirt" {
+  uri = var.libvirt_uri
+}

--- a/2022_07_15-traefik-load-balancing/terraform/tpl/ansible_hosts.tpl
+++ b/2022_07_15-traefik-load-balancing/terraform/tpl/ansible_hosts.tpl
@@ -1,0 +1,21 @@
+[all]
+%{ for vm in vms ~}
+${vm.name} ansible_ssh_host=${cidrhost(subnet, vm.ip)} host_ip=${cidrhost(subnet, vm.ip)} host_name=${vm.name}
+%{ endfor }
+
+[all:vars]
+gateway=${gateway}
+mask=${mask}
+nameserver=${nameserver}
+ansible_ssh_common_args=-o StrictHostKeyChecking=no
+ansible_python_interpreter=/usr/bin/python3
+
+
+%{ for group in ["keepalived", "traefik", "traefikee", "fakeservice", "kubernetes", "bird", "cluster1", "cluster2", "cluster3"] }
+[${group}]
+%{ for vm in vms ~}
+%{ if contains(vm.groups, group) ~}
+${vm.name}%{ for key, value in vm.vars } ${key}=${value}%{ endfor}
+%{ endif ~}
+%{ endfor }
+%{ endfor }

--- a/2022_07_15-traefik-load-balancing/terraform/tpl/group_vars.tpl
+++ b/2022_07_15-traefik-load-balancing/terraform/tpl/group_vars.tpl
@@ -1,0 +1,6 @@
+vip: "${cidrhost(subnet, vip)}/${element(split("/", subnet), 1)}"
+backends: "${join(",", [
+    for backend in backends:
+        format("http://%s:%s", backend.ip == "127.0.0.1" ? backend.ip : cidrhost(subnet, tonumber(backend.ip)), backend.port)
+    ])}"
+%{ if keepalived_conf != "" }${keepalived_conf}%{ endif }

--- a/2022_07_15-traefik-load-balancing/terraform/traefik.tf
+++ b/2022_07_15-traefik-load-balancing/terraform/traefik.tf
@@ -1,0 +1,119 @@
+resource "libvirt_network" "network" {
+  name      = "traefik"
+  mode      = "nat"
+  domain    = "traefik.local"
+  addresses = [var.subnet]
+  dhcp {
+    enabled = true
+  }
+  dns {
+    enabled    = true
+    local_only = true
+  }
+}
+
+resource "libvirt_pool" "images" {
+  name = "images"
+  type = "dir"
+  path = "/var/lib/libvirt/images/images"
+}
+
+resource "libvirt_volume" "disk" {
+  count            = length(var.vms)
+  name             = "${var.vms[count.index].name}.qcow2"
+  pool             = libvirt_pool.images.name
+  base_volume_name = var.template_img
+  base_volume_pool = var.templates_pool
+}
+
+resource "libvirt_domain" "vm" {
+  count = length(var.vms)
+  name  = var.vms[count.index].name
+
+  autostart  = true
+
+  vcpu   = lookup(var.vms[count.index], "cpu", 1)
+  memory = lookup(var.vms[count.index], "memory", 512)
+
+  network_interface {
+    network_id     = libvirt_network.network.id
+    network_name   = libvirt_network.network.name
+    wait_for_lease = true
+  }
+
+  boot_device {
+    dev = ["hd"]
+  }
+
+  disk {
+    volume_id = libvirt_volume.disk[count.index].id
+  }
+
+  console {
+    type        = "pty"
+    target_type = "serial"
+    target_port = "0"
+  }
+
+  provisioner "ansible" {
+    when = create
+
+    connection {
+      type        = "ssh"
+      host        = self.network_interface.0.addresses.0
+      user        = "root"
+      private_key = file(var.ssh_key)
+    }
+
+    ansible_ssh_settings {
+      connect_timeout_seconds                      = 10
+      connection_attempts                          = 10
+      ssh_keyscan_timeout                          = 60
+      insecure_no_strict_host_key_checking         = false
+      insecure_bastion_no_strict_host_key_checking = false
+      user_known_hosts_file                        = ""
+      bastion_user_known_hosts_file                = ""
+    }
+
+    plays {
+      playbook {
+        file_path      = "../ansible/post_install.yml"
+        force_handlers = false
+        tags           = ["base"]
+      }
+      hosts = [self.network_interface.0.addresses.0]
+      extra_vars = {
+        host_ip    = cidrhost(var.subnet, var.vms[count.index].ip)
+        host_name  = "${var.vms[count.index].name}.traefik.local"
+        gateway    = cidrhost(var.subnet, 1)
+        mask       = cidrnetmask(var.subnet)
+        nameserver = cidrhost(var.subnet, 1)
+      }
+    }
+  }
+}
+
+resource "local_file" "ansible_hosts" {
+  content = templatefile("./tpl/ansible_hosts.tpl", {
+    vms        = var.vms,
+    subnet     = var.subnet,
+    gateway    = cidrhost(var.subnet, 1),
+    mask       = cidrnetmask(var.subnet),
+    nameserver = cidrhost(var.subnet, 1)
+  })
+  filename             = "../ansible/traefik_inventory"
+  file_permission      = 0644
+  directory_permission = 0755
+}
+
+resource "local_file" "group_vars" {
+  content = templatefile("./tpl/group_vars.tpl", {
+    subnet          = var.subnet,
+    vip             = var.vip,
+    keepalived_conf = "%{if var.keepalived_pass != null}keepalived_pass: \"${var.keepalived_pass}\"\n%{endif}%{if var.keepalived_router_id != null}keepalived_router_id: ${var.keepalived_router_id}\n%{endif}%{if var.keepalived_check != null}keepalived_check: \"${var.keepalived_check}\"\n%{endif}",
+    backends        = var.backends
+  })
+  filename             = "../ansible/group_vars/cluster${var.cluster}.yaml"
+  file_permission      = 0644
+  directory_permission = 0755
+}

--- a/2022_07_15-traefik-load-balancing/terraform/variables.tf
+++ b/2022_07_15-traefik-load-balancing/terraform/variables.tf
@@ -1,0 +1,64 @@
+variable "vms" {
+  type    = list
+  default = []
+}
+
+variable "cluster" {
+  type    = number
+  default = 1
+}
+
+variable "keepalived_pass" {
+  type    = string
+  default = null
+}
+
+variable "vip" {
+  type    = number
+  default = null
+}
+
+variable "keepalived_router_id" {
+  type    = number
+  default = null
+}
+
+variable "keepalived_check" {
+  type    = string
+  default = null
+}
+
+variable "backends" {
+  type    = list
+  default = null
+}
+
+variable "network_bridge" {
+  type    = string
+  default = "virbr0"
+}
+
+variable "subnet" {
+  type    = string
+  default = "192.168.1.0/24"
+}
+
+variable "ssh_key" {
+  type    = string
+  default = "~/.ssh/id_rsa"
+}
+
+variable "libvirt_uri" {
+  type    = string
+  default = "qemu:///system"
+}
+
+variable "templates_pool" {
+  type    = string
+  default = "templates"
+}
+
+variable "template_img" {
+  type    = string
+  default = "debian11-traefik.qcow2"
+}


### PR DESCRIPTION
Update repo for Traefik LB expert guide
Traefik version 2.8.1
TraefikEE version 2.7.0

tested and validated on Debian host version 11 and Ubuntu 20.04